### PR TITLE
xfpga: use single source of truth for mmap flags

### DIFF
--- a/plugins/xfpga/buffer.c
+++ b/plugins/xfpga/buffer.c
@@ -43,35 +43,6 @@
 #include <stdbool.h>
 #include <unistd.h>
 
-/* Others */
-#define KB 1024
-#define MB (1024 * KB)
-#define GB (1024UL * MB)
-
-#define PROTECTION (PROT_READ | PROT_WRITE)
-
-#ifndef MAP_HUGETLB
-#define MAP_HUGETLB 0x40000
-#endif
-#ifndef MAP_HUGE_SHIFT
-#define MAP_HUGE_SHIFT 26
-#endif
-
-#define MAP_1G_HUGEPAGE	(0x1e << MAP_HUGE_SHIFT) /* 2 ^ 0x1e = 1G */
-
-#ifdef __ia64__
-#define ADDR (void *)(0x8000000000000000UL)
-#define FLAGS_4K (MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED)
-#define FLAGS_2M (FLAGS_4K | MAP_HUGETLB)
-#define FLAGS_1G (FLAGS_2M | MAP_1G_HUGEPAGE)
-#else
-#define ADDR (void *)(0x0UL)
-#define FLAGS_4K (MAP_PRIVATE | MAP_ANONYMOUS)
-#define FLAGS_2M (FLAGS_4K | MAP_HUGETLB)
-#define FLAGS_1G (FLAGS_2M | MAP_1G_HUGEPAGE)
-#endif
-
-
 /*
  * Allocate (mmap) new buffer
  */

--- a/plugins/xfpga/common.c
+++ b/plugins/xfpga/common.c
@@ -35,34 +35,6 @@
 #include <stdarg.h>
 #include <stdlib.h>
 
-// Buffer Allocation constants
-#define KB 1024
-#define MB (1024 * KB)
-#define GB (1024 * MB)
-
-#ifndef MAP_HUGETLB
-#define MAP_HUGETLB 0x40000
-#endif
-#ifndef MAP_HUGE_SHIFT
-#define MAP_HUGE_SHIFT 26
-#endif
-#define MAP_1G_HUGEPAGE (0x1e << MAP_HUGE_SHIFT)
-
-#define PROTECTION (PROT_READ | PROT_WRITE)
-
-#ifdef __ia64__
-#define ADDR (void *)(0x8000000000000000UL)
-#define FLAGS_4K (MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED)
-#define FLAGS_2M (FLAGS_4K | MAP_HUGETLB)
-#define FLAGS_1G (FLAGS_2M | MAP_1G_HUGEPAGE)
-#else
-#define ADDR (void *)(0x0UL)
-#define FLAGS_4K (MAP_PRIVATE | MAP_ANONYMOUS)
-#define FLAGS_2M (FLAGS_4K | MAP_HUGETLB)
-#define FLAGS_1G (FLAGS_2M | MAP_1G_HUGEPAGE)
-#endif
-
-
 /*
  * Check properties object for validity and lock its mutex
  * If prop_check_and_lock() returns FPGA_OK, assume the mutex to be locked.

--- a/plugins/xfpga/common_int.h
+++ b/plugins/xfpga/common_int.h
@@ -56,6 +56,34 @@
 		   + __GNUC_MINOR__ * 100 \
 		   + __GNUC_PATCHLEVEL__)
 
+#define KB 1024
+#define MB (1024 * KB)
+#define GB (1024UL * MB)
+
+#define PROTECTION (PROT_READ | PROT_WRITE)
+
+#ifndef MAP_HUGETLB
+#define MAP_HUGETLB 0x40000
+#endif
+#ifndef MAP_HUGE_SHIFT
+#define MAP_HUGE_SHIFT 26
+#endif
+
+#define MAP_2M_HUGEPAGE (0x15 << MAP_HUGE_SHIFT) /* 2 ^ 0x15 = 2M */
+#define MAP_1G_HUGEPAGE (0x1e << MAP_HUGE_SHIFT) /* 2 ^ 0x1e = 1G */
+
+#ifdef __ia64__
+#define ADDR (void *)(0x8000000000000000UL)
+#define FLAGS_4K (MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED)
+#define FLAGS_2M (FLAGS_4K | MAP_2M_HUGEPAGE | MAP_HUGETLB)
+#define FLAGS_1G (FLAGS_4K | MAP_1G_HUGEPAGE | MAP_HUGETLB)
+#else
+#define ADDR (void *)(0x0UL)
+#define FLAGS_4K (MAP_PRIVATE | MAP_ANONYMOUS)
+#define FLAGS_2M (FLAGS_4K | MAP_2M_HUGEPAGE | MAP_HUGETLB)
+#define FLAGS_1G (FLAGS_4K | MAP_1G_HUGEPAGE | MAP_HUGETLB)
+#endif
+
 /* Check validity of various objects */
 fpga_result prop_check_and_lock(struct _fpga_properties *prop);
 fpga_result handle_check_and_lock(struct _fpga_handle *handle);

--- a/plugins/xfpga/mmap.c
+++ b/plugins/xfpga/mmap.c
@@ -30,35 +30,7 @@
 
 #include <opae/log.h>
 #include "mmap_int.h"
-
-#include <sys/mman.h>
-
-// Buffer Allocation constants
-#define KB 1024
-#define MB (1024 * KB)
-#define GB (1024 * MB)
-
-#ifndef MAP_HUGETLB
-#define MAP_HUGETLB 0x40000
-#endif
-#ifndef MAP_HUGE_SHIFT
-#define MAP_HUGE_SHIFT 26
-#endif
-#define MAP_1G_HUGEPAGE	(0x1e << MAP_HUGE_SHIFT)
-
-#define PROTECTION (PROT_READ | PROT_WRITE)
-
-#ifdef __ia64__
-#define ADDR (void *)(0x8000000000000000UL)
-#define FLAGS_4K (MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED)
-#define FLAGS_2M (FLAGS_4K | MAP_HUGETLB)
-#define FLAGS_1G (FLAGS_2M | MAP_1G_HUGEPAGE)
-#else
-#define ADDR (void *)(0x0UL)
-#define FLAGS_4K (MAP_PRIVATE | MAP_ANONYMOUS)
-#define FLAGS_2M (FLAGS_4K | MAP_HUGETLB)
-#define FLAGS_1G (FLAGS_2M | MAP_1G_HUGEPAGE)
-#endif
+#include "common_int.h"
 
 void *alloc_buffer(uint64_t len)
 {

--- a/tests/opae-cxx/test_buffer_cxx_core.cpp
+++ b/tests/opae-cxx/test_buffer_cxx_core.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018, Intel Corporation
+// Copyright(c) 2018-2020, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -24,26 +24,13 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#define PROTECTION (PROT_READ | PROT_WRITE)
-#ifdef __ia64__
-#define ADDR (void *)(0x8000000000000000UL)
-#define FLAGS_4K (MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED)
-#define FLAGS_2M (FLAGS_4K | MAP_HUGETLB)
-#define FLAGS_1G (FLAGS_2M | MAP_1G_HUGEPAGE)
-#else
-#define ADDR (void *)(0x0UL)
-#define FLAGS_4K (MAP_PRIVATE | MAP_ANONYMOUS)
-#define FLAGS_2M (FLAGS_4K | MAP_HUGETLB)
-#define FLAGS_1G (FLAGS_2M | MAP_1G_HUGEPAGE)
-#endif
-
 #include "mock/test_system.h"
 #include "gtest/gtest.h"
 #include <opae/cxx/core/handle.h>
 #include <opae/cxx/core/properties.h>
 #include <opae/cxx/core/shared_buffer.h>
 #include <opae/cxx/core/token.h>
-#include <sys/mman.h>
+#include "common_int.h"
 
 using namespace opae::testing;
 using namespace opae::fpga::types;

--- a/tests/xfpga/test_buffer_c.cpp
+++ b/tests/xfpga/test_buffer_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2017-2018, Intel Corporation
+// Copyright(c) 2017-2020, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -33,6 +33,7 @@ extern "C" {
 }
 
 #include "error_int.h"
+#include "common_int.h"
 #include <tuple>
 #include "xfpga.h"
 #include "gtest/gtest.h"
@@ -48,19 +49,6 @@ extern "C" {
 #include <string>
 #include "safe_string/safe_string.h"
 #include <algorithm>
-#define PROTECTION (PROT_READ | PROT_WRITE)
-
-#ifdef __ia64__
-#define ADDR (void*)(0x8000000000000000UL)
-#define FLAGS_4K (MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED)
-#define FLAGS_2M (FLAGS_4K | MAP_HUGETLB)
-#define FLAGS_1G (FLAGS_2M | MAP_1G_HUGEPAGE)
-#else
-#define ADDR (void*)(0x0UL)
-#define FLAGS_4K (MAP_PRIVATE | MAP_ANONYMOUS)
-#define FLAGS_2M (FLAGS_4K | MAP_HUGETLB)
-#define FLAGS_1G (FLAGS_2M | MAP_1G_HUGEPAGE)
-#endif
 
 #define NLB_DSM_SIZE (2 * 1024 * 1024)
 #define KB 1024


### PR DESCRIPTION
Previously, the mmap flags used by the huge page allocation code
were replicated in several of the source files and even in some of
the test code. Move the flags to common_int.h and use that as the
single definition of the flags.

Allocation requests for 2MB hugepages were being satisfied from
the kernel's default huge page pool. Change the 2MB allocation flags
to explicitly request these of the 2MB pool.