### PR TITLE
cmake: add OPAE_PRESERVE_REPOS option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,9 @@ mark_as_advanced(OPAE_ENABLE_MOCK)
 option(OPAE_BUILD_SIM "Enable building of the AFU simulation environment" OFF)
 mark_as_advanced(OPAE_BUILD_SIM)
 
+option(OPAE_PRESERVE_REPOS "Disable refresh of external repos" OFF)
+mark_as_advanced(OPAE_PRESERVE_REPOS)
+
 ############################################################################
 ## Add Subdirectories ######################################################
 ############################################################################

--- a/cmake/modules/OPAEExternal.cmake
+++ b/cmake/modules/OPAEExternal.cmake
@@ -24,11 +24,10 @@
 ## CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
 ## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 ## POSSIBILITY OF SUCH DAMAGE
-cmake_minimum_required (VERSION 2.8)
 
 macro(opae_external_project_add)
     set(options EXCLUDE_FROM_ALL NO_ADD_SUBDIRECTORY)
-    set(oneValueArgs PROJECT_NAME GIT_URL GIT_TAG)
+    set(oneValueArgs PROJECT_NAME GIT_URL GIT_TAG PRESERVE_REPOS)
     set(multiValueArgs)
     cmake_parse_arguments(OPAE_EXTERNAL_PROJECT_ADD "${options}"
         "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
@@ -57,21 +56,24 @@ macro(opae_external_project_add)
         "    COMMENT \"adding ${OPAE_EXTERNAL_PROJECT_ADD_PROJECT_NAME}\"\n"
         ")\n"
     )
-    execute_process(
-        COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-        RESULT_VARIABLE result
-        WORKING_DIRECTORY ${download_dir})
-    if(result)
-        message(FATAL_ERROR "CMake step for ${OPAE_EXTERNAL_PROJECT_ADD_PROJECT_NAME} failed: ${result}")
-    endif(result)
 
-    execute_process(
-        COMMAND ${CMAKE_COMMAND} --build .
-        RESULT_VARIABLE result
-        WORKING_DIRECTORY ${download_dir})
-    if(result)
-        message(FATAL_ERROR "Build step for ${OPAE_EXTERNAL_PROJECT_ADD_PROJECT_NAME} failed: ${result}")
-    endif(result)
+    if(NOT EXISTS ${CMAKE_SOURCE_DIR}/external/${OPAE_EXTERNAL_PROJECT_ADD_PROJECT_NAME} OR NOT ${OPAE_EXTERNAL_PROJECT_ADD_PRESERVE_REPOS})
+        execute_process(
+            COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+            RESULT_VARIABLE result
+            WORKING_DIRECTORY ${download_dir})
+        if(result)
+            message(FATAL_ERROR "CMake step for ${OPAE_EXTERNAL_PROJECT_ADD_PROJECT_NAME} failed: ${result}")
+        endif(result)
+
+        execute_process(
+            COMMAND ${CMAKE_COMMAND} --build .
+            RESULT_VARIABLE result
+            WORKING_DIRECTORY ${download_dir})
+        if(result)
+            message(FATAL_ERROR "Build step for ${OPAE_EXTERNAL_PROJECT_ADD_PROJECT_NAME} failed: ${result}")
+        endif(result)
+    endif()
 
     if(NOT ${OPAE_EXTERNAL_PROJECT_ADD_NO_ADD_SUBDIRECTORY})
         if(${OPAE_EXTERNAL_PROJECT_ADD_EXCLUDE_FROM_ALL})

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -28,10 +28,12 @@ cmake_minimum_required(VERSION 2.8.12)
 
 if(OPAE_BUILD_TESTS)
     opae_external_project_add(PROJECT_NAME opae-test
-                              GIT_URL https://github.com/OPAE/opae-test.git)
+                              GIT_URL https://github.com/OPAE/opae-test.git
+                              PRESERVE_REPOS ${OPAE_PRESERVE_REPOS})
 endif(OPAE_BUILD_TESTS)
 
 if(OPAE_BUILD_SIM)
     opae_external_project_add(PROJECT_NAME opae-sim
-                              GIT_URL https://github.com/OPAE/opae-sim.git)
+                              GIT_URL https://github.com/OPAE/opae-sim.git
+                              PRESERVE_REPOS ${OPAE_PRESERVE_REPOS})
 endif(OPAE_BUILD_SIM)


### PR DESCRIPTION
Add option to skip refreshing the repos controlled by
opae_external_project_add. This preserves any local changes to
the repos that live within an external/ directory.