### PR TITLE
cmake: add OPAE_TEST_TAG and OPAE_SIM_TAG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,12 @@ mark_as_advanced(OPAE_BUILD_SIM)
 option(OPAE_PRESERVE_REPOS "Disable refresh of external repos" OFF)
 mark_as_advanced(OPAE_PRESERVE_REPOS)
 
+option(OPAE_TEST_TAG "Desired branch for opae-test" master)
+mark_as_advanced(OPAE_TEST_TAG)
+
+option(OPAE_SIM_TAG "Desired branch for opae-sim" master)
+mark_as_advanced(OPAE_SIM_TAG)
+
 ############################################################################
 ## Add Subdirectories ######################################################
 ############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,11 +98,15 @@ mark_as_advanced(OPAE_BUILD_SIM)
 option(OPAE_PRESERVE_REPOS "Disable refresh of external repos" OFF)
 mark_as_advanced(OPAE_PRESERVE_REPOS)
 
-option(OPAE_TEST_TAG "Desired branch for opae-test" master)
-mark_as_advanced(OPAE_TEST_TAG)
+if(OPAE_BUILD_TESTS)
+    option(OPAE_TEST_TAG "Desired branch for opae-test" master)
+    mark_as_advanced(OPAE_TEST_TAG)
+endif(OPAE_BUILD_TESTS)
 
-option(OPAE_SIM_TAG "Desired branch for opae-sim" master)
-mark_as_advanced(OPAE_SIM_TAG)
+if(OPAE_BUILD_SIM)
+    option(OPAE_SIM_TAG "Desired branch for opae-sim" master)
+    mark_as_advanced(OPAE_SIM_TAG)
+endif(OPAE_BUILD_SIM)
 
 ############################################################################
 ## Add Subdirectories ######################################################

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -29,11 +29,13 @@ cmake_minimum_required(VERSION 2.8.12)
 if(OPAE_BUILD_TESTS)
     opae_external_project_add(PROJECT_NAME opae-test
                               GIT_URL https://github.com/OPAE/opae-test.git
+                              GIT_TAG ${OPAE_TEST_TAG}
                               PRESERVE_REPOS ${OPAE_PRESERVE_REPOS})
 endif(OPAE_BUILD_TESTS)
 
 if(OPAE_BUILD_SIM)
     opae_external_project_add(PROJECT_NAME opae-sim
                               GIT_URL https://github.com/OPAE/opae-sim.git
+                              GIT_TAG ${OPAE_SIM_TAG}
                               PRESERVE_REPOS ${OPAE_PRESERVE_REPOS})
 endif(OPAE_BUILD_SIM)


### PR DESCRIPTION
Allows specifying the git tag to load for the corresponding external
repository.