### PR TITLE
xfpga: add FPGA_RECONF_SKIP_USRCLK flag

### DIFF
--- a/include/opae/types_enum.h
+++ b/include/opae/types_enum.h
@@ -142,7 +142,9 @@ enum fpga_open_flags {
  */
 enum fpga_reconf_flags {
 	/** Reconfigure the slot without checking if it is in use */
-	FPGA_RECONF_FORCE = (1u << 0)
+	FPGA_RECONF_FORCE = (1u << 0),
+	/** Don't configure AFU user clocks as part of PR */
+	FPGA_RECONF_SKIP_USRCLK = (1u << 1)
 };
 
 enum fpga_sysobject_flags {

--- a/plugins/xfpga/reconf.c
+++ b/plugins/xfpga/reconf.c
@@ -392,12 +392,18 @@ fpga_result __XFPGA_API__ xfpga_fpgaReconfigureSlot(fpga_handle fpga,
 		OPAE_DBG(" AFU_uuid                 :%s\n",
 			 metadata.afu_image.afu_clusters.afu_uuid);
 
+
 		// Set AFU user clock
-		if (metadata.afu_image.clock_frequency_high > 0 || metadata.afu_image.clock_frequency_low > 0) {
-			result = set_afu_userclock(fpga, metadata.afu_image.clock_frequency_high, metadata.afu_image.clock_frequency_low);
-			if (result != FPGA_OK) {
-				OPAE_ERR("Failed to set user clock");
-				goto out_unlock;
+		if (!(flags & FPGA_RECONF_SKIP_USRCLK)) {
+			if (metadata.afu_image.clock_frequency_high > 0 ||
+			    metadata.afu_image.clock_frequency_low > 0) {
+				result = set_afu_userclock(fpga,
+						metadata.afu_image.clock_frequency_high,
+						metadata.afu_image.clock_frequency_low);
+				if (result != FPGA_OK) {
+					OPAE_ERR("Failed to set user clock");
+					goto out_unlock;
+				}
 			}
 		}
 


### PR DESCRIPTION
When provided as a part of the flags parameter to fpgaReconfigureSlot(),
this flag causes the AFU user clocks programming step to be skipped.