### PR TITLE
Fix possible buffer overflow

### DIFF
--- a/plugins/xfpga/sysfs.c
+++ b/plugins/xfpga/sysfs.c
@@ -1793,7 +1793,7 @@ fpga_result sysfs_sbdf_from_path(const char *sysfspath, int *s, int *b, int *d,
 	char rlpath[SYSFS_PATH_MAX];
 	char *p;
 
-	res = readlink(sysfspath, rlpath, sizeof(rlpath));
+	res = readlink(sysfspath, rlpath, sizeof(rlpath)-1);
 	if (-1 == res) {
 		OPAE_MSG("Can't read link %s (no driver?)", sysfspath);
 		return FPGA_NO_DRIVER;


### PR DESCRIPTION
readlink returns the number of bytes written.
If that fills the buffer, then the NULL assignment will overflow.
Reduce the buffer size parameter in readlink by 1 to
ensure there is space for the NULL.

Signed-off-by: Tom Rix <trix@redhat.com>