### PR TITLE
xfpga: fix irq use in events API

### DIFF
--- a/plugins/xfpga/event.c
+++ b/plugins/xfpga/event.c
@@ -205,7 +205,7 @@ STATIC fpga_result send_uafu_event_request(fpga_handle handle,
 			}
 			data = &fd;
 			// assigning irq uses flags as the irq num.
-			// set the bit it in the handle irq setr
+			// set the bit it in the handle irq set
 			// and stash the number in the event handle
 			_handle->irq_set |= (1 << flags);
 			_eh->flags = flags;

--- a/plugins/xfpga/event.c
+++ b/plugins/xfpga/event.c
@@ -186,9 +186,13 @@ STATIC fpga_result send_uafu_event_request(fpga_handle handle,
 
 	if (!_handle->num_irqs) {
 		res = opae_dfl_port_get_user_irq(_handle->fddev, &num_irqs);
-		if (res || !num_irqs) {
-			OPAE_ERR("Port user interrupts not supported in hw");
+		if (res) {
+			OPAE_ERR("Invalid param or not supported");
 			return res;
+		}
+		if (!num_irqs) {
+			OPAE_ERR("Port user interrupts not supported in hw");
+			return FPGA_NOT_SUPPORTED;
 		}
 		_handle->num_irqs = num_irqs;
 	}
@@ -205,7 +209,7 @@ STATIC fpga_result send_uafu_event_request(fpga_handle handle,
 			}
 			data = &fd;
 			// assigning irq uses flags as the irq num.
-			// set the bit it in the handle irq set
+			// set the bit in the handle irq set
 			// and stash the number in the event handle
 			_handle->irq_set |= (1 << flags);
 			_eh->flags = flags;

--- a/plugins/xfpga/event.c
+++ b/plugins/xfpga/event.c
@@ -151,7 +151,7 @@ STATIC fpga_result send_port_event_request(fpga_handle handle,
 	}
 
 	if (num_irqs > 0) {
-		res = opae_dfl_port_set_err_irq(_handle->fddev, 0, 1, 
+		res = opae_dfl_port_set_err_irq(_handle->fddev, 0, 1,
 			&fd);
 		if (res) {
 			OPAE_ERR("Could not set eventfd %s", strerror(errno));
@@ -170,7 +170,10 @@ STATIC fpga_result send_uafu_event_request(fpga_handle handle,
 {
 	int res = FPGA_OK;
 	int fd = FILE_DESCRIPTOR(event_handle);
+	int *data = NULL;
 	struct _fpga_handle *_handle = (struct _fpga_handle *)handle;
+	struct _fpga_event_handle *_eh =
+		(struct _fpga_event_handle *)event_handle;
 	uint32_t num_irqs = 0;
 	int32_t neg = -1;
 	UNUSED_PARAM(flags);
@@ -181,27 +184,52 @@ STATIC fpga_result send_uafu_event_request(fpga_handle handle,
 		return FPGA_INVALID_PARAM;
 	}
 
-	res = opae_dfl_port_get_user_irq(_handle->fddev, &num_irqs);
+	if (!_handle->num_irqs) {
+		res = opae_dfl_port_get_user_irq(_handle->fddev, &num_irqs);
+		if (res || !num_irqs) {
+			OPAE_ERR("Port user interrupts not supported in hw");
+			return res;
+		}
+		_handle->num_irqs = num_irqs;
+	}
+
+	switch(uafu_operation) {
+		case FPGA_IRQ_ASSIGN:
+			if (flags >= _handle->num_irqs) {
+				OPAE_ERR("Max IRQs reached");
+				return FPGA_INVALID_PARAM;
+			}
+			if (_handle->irq_set & (1 << flags)) {
+				OPAE_ERR("IRQ index already in use");
+				return FPGA_INVALID_PARAM;
+			}
+			data = &fd;
+			// assigning irq uses flags as the irq num.
+			// set the bit it in the handle irq setr
+			// and stash the number in the event handle
+			_handle->irq_set |= (1 << flags);
+			_eh->flags = flags;
+			break;
+		case FPGA_IRQ_DEASSIGN:
+			// unassigning has flags set to 0
+			// get the irq number from the event handle
+			flags = _eh->flags;
+			if (!(_handle->irq_set & (1 << flags))) {
+				OPAE_DBG("IRQ not assigned");
+				return FPGA_INVALID_PARAM;
+			}
+			data = &neg;
+			_handle->irq_set &= ~(1 << flags);
+			break;
+		default:
+			OPAE_ERR("Invalid uafu operation");
+			return FPGA_EXCEPTION;
+	}
+	res = opae_dfl_port_set_user_irq(_handle->fddev, flags, 1, data);
+
 	if (res) {
-		OPAE_ERR("Port user interrupts not supported in hw");
-		return res;
-	}
-
-	if (num_irqs > 0) {
-		if (uafu_operation == FPGA_IRQ_ASSIGN) {
-			res = opae_dfl_port_set_user_irq(_handle->fddev, 0, 1, &fd);
-		} else {
-			res = opae_dfl_port_set_user_irq(_handle->fddev, 0, 1, &neg);
-		}
-
-		if (res) {
-			OPAE_ERR("Could not set eventfd");
-			res = FPGA_EXCEPTION;
-		}
-	}
-	else {
-		OPAE_ERR("PORT interrupts not supported in hw");
-		res = FPGA_NOT_SUPPORTED;
+		OPAE_ERR("Could not set eventfd");
+		res = FPGA_EXCEPTION;
 	}
 
 	return res;
@@ -231,8 +259,7 @@ STATIC fpga_result check_user_interrupts_supported(fpga_handle handle,
 	if (*objtype == FPGA_DEVICE) {
 			OPAE_MSG("Interrupts not supported in hw");
 			res = FPGA_NOT_SUPPORTED;
-	}
-	else if (*objtype == FPGA_ACCELERATOR) {
+	} else if (*objtype == FPGA_ACCELERATOR) {
 		res = opae_dfl_port_get_user_irq(_handle->fddev, &num_irqs);
 		if (res) {
 			OPAE_ERR("Interrupts not supported in hw: %d", res);
@@ -241,8 +268,7 @@ STATIC fpga_result check_user_interrupts_supported(fpga_handle handle,
 
 		if (num_irqs > 0) {
 			res = FPGA_OK;
-		}
-		else {
+		} else {
 			OPAE_ERR("Interrupts not supported in hw: %d", res);
 			res = FPGA_NOT_SUPPORTED;
 		}
@@ -297,12 +323,10 @@ STATIC fpga_result check_err_interrupts_supported(fpga_handle handle,
 			OPAE_MSG("Interrupts not supported in hw");
 			res = FPGA_NOT_SUPPORTED;
 		}
-	}
-	else if (*objtype == FPGA_ACCELERATOR) {
+	} else if (*objtype == FPGA_ACCELERATOR) {
 		res = opae_dfl_port_get_err_irq(_handle->fddev, &num_irqs);
 		if (res) {
 			OPAE_MSG("Interrupts not supported in hw");
-
 			goto destroy_prop;
 		}
 
@@ -390,7 +414,7 @@ STATIC fpga_result driver_unregister_event(fpga_handle handle,
 				"Could not determine whether interrupts are supported");
 			return FPGA_NOT_SUPPORTED;
 		}
-		
+
 		if (objtype == FPGA_DEVICE) {
 			return send_fme_event_request(handle, event_handle,
 						      FPGA_IRQ_DEASSIGN);

--- a/plugins/xfpga/types_int.h
+++ b/plugins/xfpga/types_int.h
@@ -156,6 +156,8 @@ struct _fpga_handle {
 
 	int fddev;                      // file descriptor for the device.
 	int fdfpgad;                    // file descriptor for the event daemon.
+	uint32_t num_irqs;              // number of interrupts supported
+	uint32_t irq_set;               // bitmask of irqs set
 	struct wsid_tracker *wsid_root; // wsid information (list)
 	struct wsid_tracker *mmio_root; // MMIO information (list)
 	void *umsg_virt;	        // umsg Virtual Memory pointer

--- a/tests/xfpga/test_events_c.cpp
+++ b/tests/xfpga/test_events_c.cpp
@@ -846,17 +846,18 @@ TEST_P(events_mock_p, valid_uafu_event_request){
 
 /**
  * @test       send_uafu_event_request
- * @brief      When passed a valid event handle and handle
- *             with FPGA_IRQ_DEASSIGN flag. The function
- *             returns FPGA_OK.
+ * @brief      When passed a valid handle
+ *             with an event handle that hasn't been assigned
+ *             and with FPGA_IRQ_DEASSIGN in the flag. The function
+ *             returns FPGA_INVALID_PARAM.
  */
 TEST_P(events_mock_p, valid_uafu_event_request_01){
   int port_op = FPGA_IRQ_DEASSIGN;
 
   gEnableIRQ = true;
- system_->register_ioctl_handler(DFL_FPGA_PORT_UINT_GET_IRQ_NUM, dfl_get_port_uint_irq);
+  system_->register_ioctl_handler(DFL_FPGA_PORT_UINT_GET_IRQ_NUM, dfl_get_port_uint_irq);
   auto res = send_uafu_event_request(handle_dev_,eh_,0,port_op);
-  EXPECT_EQ(FPGA_OK,res);
+  EXPECT_EQ(FPGA_INVALID_PARAM, res);
 }
 
 /**
@@ -963,7 +964,7 @@ TEST_P(events_mock_p, event_drv_14) {
   // Valid magic and ioctl
   gEnableIRQ = true;
   system_->register_ioctl_handler(DFL_FPGA_PORT_UINT_GET_IRQ_NUM, dfl_get_port_uint_irq);
-  EXPECT_EQ(FPGA_OK, xfpga_fpgaUnregisterEvent(handle_accel_, FPGA_EVENT_INTERRUPT, bad_handle));
+  EXPECT_EQ(FPGA_INVALID_PARAM, xfpga_fpgaUnregisterEvent(handle_accel_, FPGA_EVENT_INTERRUPT, bad_handle));
 
   // Destory event handle
   auto res = xfpga_fpgaDestroyEventHandle(&bad_handle);
@@ -1062,7 +1063,7 @@ TEST_P(events_mock_p, invalid_uafu_event_request_02){
 /**
  * @test       fme_interrupts_check
  * @brief      When irq is not supported and register invalid ioctl,
- *             check_err_interrupts_supported returns FPGA_NOT_SUPPORTED 
+ *             check_err_interrupts_supported returns FPGA_NOT_SUPPORTED
  *             or FPGA_EXCEPTION.
  */
 TEST_P(events_mock_p, fme_interrupts_check){


### PR DESCRIPTION
The events API was always using index 0 when registering for interrupts.
Use the number of interrupts available along with a bitset of interrupts
already set for validating registering events. Also, save the interrupt
index in the event_handle data structure for associating interrupt
number with the event. This is used when unregistering for events.