### PR TITLE
Define cmake variables for controlling sample building.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,33 @@ mark_as_advanced(OPAE_BUILD_ASE_SAMPLES)
 option(OPAE_BUILD_SAMPLES "Enable building samples" ON)
 mark_as_advanced(OPAE_BUILD_SAMPLES)
 
+option(OPAE_BUILD_EXTRA_TOOLS "Enable building extra tools" ON)
+mark_as_advanced(OPAE_BUILD_EXTRA_TOOLS)
+
+option(OPAE_BUILD_EXTRA_TOOLS_USERCLK "Enable building extra tool userclk" ON)
+mark_as_advanced(OPAE_BUILD_EXTRA_TOOLS_USERCLK)
+
+option(OPAE_BUILD_EXTRA_TOOLS_PACKAGER "Enable building extra tool packager" ON)
+mark_as_advanced(OPAE_BUILD_EXTRA_TOOLS_PACKAGER)
+
+option(OPAE_BUILD_EXTRA_TOOLS_CXXUTILS "Enable building extra tool c++utils" ON)
+mark_as_advanced(OPAE_BUILD_EXTRA_TOOLS_CXXUTILS)
+
+option(OPAE_BUILD_EXTRA_TOOLS_FPGADIAG "Enable building extra tool fpgadiag" ON)
+mark_as_advanced(OPAE_BUILD_EXTRA_TOOLS_FPGADIAG)
+
+option(OPAE_BUILD_EXTRA_TOOLS_MMLINK "Enable building extra tool mmlink" ON)
+mark_as_advanced(OPAE_BUILD_EXTRA_TOOLS_MMLINK)
+
+option(OPAE_BUILD_EXTRA_TOOLS_RAS "Enable building extra tool ras" ON)
+mark_as_advanced(OPAE_BUILD_EXTRA_TOOLS_RAS)
+
+option(OPAE_BUILD_EXTRA_TOOLS_PAC_HSSI_CONFIG  "Enable building extra tool pac_hssi_config" ON)
+mark_as_advanced(OPAE_BUILD_EXTRA_TOOLS_PAC_HSSI_CONFIG)
+
+option(OPAE_BUILD_EXTRA_TOOLS_FPGABIST "Enable building extra tool fpgabist" OFF)
+mark_as_advanced(OPAE_BUILD_EXTRA_TOOLS_FPGABIST)
+
 option(OPAE_PRESERVE_REPOS "Disable refresh of external repos" OFF)
 mark_as_advanced(OPAE_PRESERVE_REPOS)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,12 @@ mark_as_advanced(OPAE_ENABLE_MOCK)
 option(OPAE_BUILD_SIM "Enable building of the AFU simulation environment" OFF)
 mark_as_advanced(OPAE_BUILD_SIM)
 
+option(OPAE_BUILD_ASE_SAMPLES "Enable building ASE samples" OFF)
+mark_as_advanced(OPAE_BUILD_ASE_SAMPLES)
+
+option(OPAE_BUILD_SAMPLES "Enable building samples" ON)
+mark_as_advanced(OPAE_BUILD_SAMPLES)
+
 option(OPAE_PRESERVE_REPOS "Disable refresh of external repos" OFF)
 mark_as_advanced(OPAE_PRESERVE_REPOS)
 


### PR DESCRIPTION
In some cases building the samples is not needed.
So define some top level options to control their building.

OPAE_BUILD_ASE_SAMPLES will replace the existing BUILD_ASE_SAMPLES

OPAE_BUILD_SAMPLES is new and will control building of
all the non ASE samples.

Signed-off-by: Tom Rix <trix@redhat.com>