### PR TITLE
A static analysis check

### DIFF
--- a/include/opae/cxx/core/pvalue.h
+++ b/include/opae/cxx/core/pvalue.h
@@ -93,9 +93,8 @@ struct guid_t {
    * @param[in] str The guid string.
    */
   void parse(const char *str) {
-    int u;
     is_set_ = false;
-    if (0 != (u = uuid_parse(str, data_.data()))) {
+    if (0 != uuid_parse(str, data_.data())) {
       throw except(OPAECXX_HERE);
     }
     ASSERT_FPGA_OK(fpgaPropertiesSetGUID(*props_, data_.data()));

--- a/plugins/xfpga/metrics/afu_metrics.c
+++ b/plugins/xfpga/metrics/afu_metrics.c
@@ -158,10 +158,11 @@ fpga_result get_afu_metric_value(fpga_handle handle,
 		if (metric_num == _fpga_enum_metric->metric_num) {
 
 			result = xfpga_fpgaReadMMIO64(handle, 0, _fpga_enum_metric->mmio_offset, &metric_csr.csr);
-
-				fpga_metric->value.ivalue = metric_csr.value;
-				result = FPGA_OK;
-
+			if (result != FPGA_OK) {
+				OPAE_ERR("Failed to get metric");
+				break;
+			}
+			fpga_metric->value.ivalue = metric_csr.value;
 		}
 
 	}

--- a/plugins/xfpga/metrics/metrics_utils.c
+++ b/plugins/xfpga/metrics/metrics_utils.c
@@ -323,7 +323,10 @@ fpga_result  enum_bmc_metrics_info(struct _fpga_handle *_handle,
 
 	for (x = 0; x < num_sensors; x++) {
 		result = xfpga_bmcGetSDRDetails(_handle, values, x, &details);
-
+		if (result != FPGA_OK) {
+			OPAE_ERR("Failed to get sensor details.");
+			return result;
+		}
 
 		if (details.sensor_type == BMC_THERMAL) {
 


### PR DESCRIPTION
Using clang static analyzer scan-build turns up a few issues.
Fixing the not returning failures is the more serious.