### PR TITLE
pyopae: change 'find' to use glob, fix tests

### DIFF
--- a/pyopae/opae.cpp
+++ b/pyopae/opae.cpp
@@ -190,7 +190,7 @@ PYBIND11_MODULE(_opae, m) {
   pytoken.def("__getattr__", token_get_sysobject, sysobject_doc_token_get())
       .def("__getitem__", token_get_sysobject, sysobject_doc_token_get())
       .def("find", token_find_sysobject, sysobject_doc_token_find(),
-           py::arg("name"), py::arg("flags") = 0);
+           py::arg("name"), py::arg("flags") = FPGA_OBJECT_GLOB);
 
   // define handle class
   m.def("open", handle_open, handle_doc_open(), py::arg("tok"),
@@ -214,7 +214,7 @@ PYBIND11_MODULE(_opae, m) {
       .def("__getattr__", handle_get_sysobject, sysobject_doc_handle_get())
       .def("__getitem__", handle_get_sysobject, sysobject_doc_handle_get())
       .def("find", handle_find_sysobject, sysobject_doc_handle_find(),
-           py::arg("name"), py::arg("flags") = 0);
+           py::arg("name"), py::arg("flags") = FPGA_OBJECT_GLOB);
 
   // define shared_buffer class
   m.def("allocate_shared_buffer", shared_buffer_allocate,

--- a/tests/pyopae/test_properties.py
+++ b/tests/pyopae/test_properties.py
@@ -33,7 +33,7 @@ class TestProperties(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.system = mockopae.test_system()
-        cls.platform = mockopae.test_platform.get("skx-p")
+        cls.platform = mockopae.test_platform.get("dfl-n3000")
         cls.system.initialize()
         cls.system.prepare_sysfs(cls.platform)
         opae.fpga.initialize(None)

--- a/tests/pyopae/test_shared_buffers.py
+++ b/tests/pyopae/test_shared_buffers.py
@@ -32,7 +32,7 @@ class TestSharedBuffer(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.system = mockopae.test_system()
-        cls.platform = mockopae.test_platform.get("skx-p")
+        cls.platform = mockopae.test_platform.get("dfl-n3000")
         cls.system.initialize()
         cls.system.prepare_sysfs(cls.platform)
         opae.fpga.initialize(None)

--- a/tests/pyopae/test_sysobject.py
+++ b/tests/pyopae/test_sysobject.py
@@ -32,7 +32,7 @@ class TestSysObject(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.system = mockopae.test_system()
-        cls.platform = mockopae.test_platform.get("skx-p")
+        cls.platform = mockopae.test_platform.get("dfl-n3000")
         cls.system.initialize()
         cls.system.prepare_sysfs(cls.platform)
         opae.fpga.initialize(None)
@@ -71,17 +71,17 @@ class TestSysObject(unittest.TestCase):
         assert u1 == u2
 
     def test_object_object(self):
-        pr = self.fme_handle.pr
-        interface_id = pr.interface_id
-        u1 = uuid.UUID(interface_id.bytes()[:-1])
+        pr = self.fme_handle.find('dfl-fme-region.*/fpga_region/region*')
+        compat_id = pr.compat_id
+        u1 = uuid.UUID(compat_id.bytes()[:-1])
         u2 = uuid.UUID(self.platform.devices[0].fme_guid)
         assert u1 == u2
 
     def test_object_read64(self):
         errors = self.afu_handle.errors
-        rev = errors.revision
-        n1 = rev.read64()
-        self.assertEquals(n1, 1)
+        err = errors.errors
+        n1 = err.read64()
+        self.assertEquals(n1, 0)
         with self.assertRaises(RuntimeError):
             print(errors.read64())
 


### PR DESCRIPTION
* change the find method binding to default to use FPGA_OBJECT_GLOB
* change test_sysobject to find sysfs objects for n3000 platform