### PR TITLE
token_list: convert OPAE_ERR to OPAE_DBG

### DIFF
--- a/plugins/xfpga/token_list.c
+++ b/plugins/xfpga/token_list.c
@@ -186,7 +186,7 @@ struct _fpga_token *token_get_parent(struct _fpga_token *_t)
 
 	res = sysfs_get_fme_path(_t->sysfspath, spath);
 	if (res) {
-		OPAE_ERR("Could not find fme path for token: %s",
+		OPAE_DBG("Could not find fme path for token: %s",
 			 _t->sysfspath);
 		return NULL;
 	}


### PR DESCRIPTION
A parent token will never exist in a virtualized environment,
because there is no fme sysfs entry. Report this as a debug
finding instead of flagging a false error.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>