### PR TITLE
Amarroqu/release 2.0.0 update submodule branchtargets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,12 +102,12 @@ option(OPAE_PRESERVE_REPOS "Disable refresh of external repos" OFF)
 mark_as_advanced(OPAE_PRESERVE_REPOS)
 
 if(OPAE_BUILD_TESTS)
-    option(OPAE_TEST_TAG "Desired branch for opae-test" master)
+    option(OPAE_TEST_TAG "Desired branch for opae-test" release/2.0.0)
     mark_as_advanced(OPAE_TEST_TAG)
 endif(OPAE_BUILD_TESTS)
 
 if(OPAE_BUILD_SIM)
-    option(OPAE_SIM_TAG "Desired branch for opae-sim" master)
+    option(OPAE_SIM_TAG "Desired branch for opae-sim" release/2.0.0)
     mark_as_advanced(OPAE_SIM_TAG)
 endif(OPAE_BUILD_SIM)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,12 +102,12 @@ option(OPAE_PRESERVE_REPOS "Disable refresh of external repos" OFF)
 mark_as_advanced(OPAE_PRESERVE_REPOS)
 
 if(OPAE_BUILD_TESTS)
-    option(OPAE_TEST_TAG "Desired branch for opae-test" release/2.0.0)
+    set(OPAE_TEST_TAG "release/2.0.0")
     mark_as_advanced(OPAE_TEST_TAG)
 endif(OPAE_BUILD_TESTS)
 
 if(OPAE_BUILD_SIM)
-    option(OPAE_SIM_TAG "Desired branch for opae-sim" release/2.0.0)
+    set(OPAE_SIM_TAG "release/2.0.0")
     mark_as_advanced(OPAE_SIM_TAG)
 endif(OPAE_BUILD_SIM)
 


### PR DESCRIPTION
Updates submodule targets to use branch `release/2.0.0`.
Also uses `SET` instead of `OPTION`, as `OPTION` seems to only work with boolean arguments.


Signed-off-by: Asgard Marroquin asgard.marroquin@intel.com