### PR TITLE
Add CACHE, DOCSTRING to submodule branch targets 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,12 +102,12 @@ option(OPAE_PRESERVE_REPOS "Disable refresh of external repos" OFF)
 mark_as_advanced(OPAE_PRESERVE_REPOS)
 
 if(OPAE_BUILD_TESTS)
-    set(OPAE_TEST_TAG "release/2.0.0" CACHE STRING "Desired branch for opae-test" FORCE)
+    set(OPAE_TEST_TAG "release/2.0.0" CACHE STRING "Desired branch for opae-test")
     mark_as_advanced(OPAE_TEST_TAG)
 endif(OPAE_BUILD_TESTS)
 
 if(OPAE_BUILD_SIM)
-    set(OPAE_SIM_TAG "release/2.0.0" CACHE STRING "Desired branch for opae-sim" FORCE)
+    set(OPAE_SIM_TAG "release/2.0.0" CACHE STRING "Desired branch for opae-sim")
     mark_as_advanced(OPAE_SIM_TAG)
 endif(OPAE_BUILD_SIM)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,12 +102,12 @@ option(OPAE_PRESERVE_REPOS "Disable refresh of external repos" OFF)
 mark_as_advanced(OPAE_PRESERVE_REPOS)
 
 if(OPAE_BUILD_TESTS)
-    set(OPAE_TEST_TAG "release/2.0.0")
+    set(OPAE_TEST_TAG "release/2.0.0" CACHE STRING "Desired branch for opae-test" FORCE)
     mark_as_advanced(OPAE_TEST_TAG)
 endif(OPAE_BUILD_TESTS)
 
 if(OPAE_BUILD_SIM)
-    set(OPAE_SIM_TAG "release/2.0.0")
+    set(OPAE_SIM_TAG "release/2.0.0" CACHE STRING "Desired branch for opae-sim" FORCE)
     mark_as_advanced(OPAE_SIM_TAG)
 endif(OPAE_BUILD_SIM)
 


### PR DESCRIPTION
Enables definition of external branch via CLI when configuring via `cmake`.