### PR TITLE
cmake: use set for OPAE_TEST_TAG and OPAE_SIM_TAG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,12 +102,12 @@ option(OPAE_PRESERVE_REPOS "Disable refresh of external repos" OFF)
 mark_as_advanced(OPAE_PRESERVE_REPOS)
 
 if(OPAE_BUILD_TESTS)
-    option(OPAE_TEST_TAG "Desired branch for opae-test" master)
+    set(OPAE_TEST_TAG "master" CACHE STRING "Desired branch for opae-test")
     mark_as_advanced(OPAE_TEST_TAG)
 endif(OPAE_BUILD_TESTS)
 
 if(OPAE_BUILD_SIM)
-    option(OPAE_SIM_TAG "Desired branch for opae-sim" master)
+    set(OPAE_SIM_TAG "master" CACHE STRING "Desired branch for opae-sim")
     mark_as_advanced(OPAE_SIM_TAG)
 endif(OPAE_BUILD_SIM)
 


### PR DESCRIPTION
The option macro only allows a boolean ON/OFF value.
Use the appropriate set command instead.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>