### PR TITLE
Specify same PYTHON_EXECUTABLE in packager as in CMake

### DIFF
--- a/cmake/modules/OPAEPackaging.cmake
+++ b/cmake/modules/OPAEPackaging.cmake
@@ -168,7 +168,7 @@ macro(CREATE_PYTHON_EXE EXE_NAME MAIN_MODULE)
         "f.close()\n")
 
     # Run Python to generate the zipped file
-    execute_process(COMMAND python "${BUILD_DIR_MAIN}/do_zip.py"
+    execute_process(COMMAND ${PYTHON_EXECUTABLE} "${BUILD_DIR_MAIN}/do_zip.py"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 endmacro(CREATE_PYTHON_EXE)


### PR DESCRIPTION
Binary artifact generation for certain binaries generated during configuration
were not being generated on some platforms (e.g. a factory RHEL8.2 machine, which
by default does not define `python`). This is because the packaging script calls
for `python` directly, rather than the `PYTHON_EXECUTABLE` found by CMake during
configuration.

Commit changes the harded coded `python` call to `PYTHON_EXECUTABLE` to ensure
that packaging for these binary artifacts is identical to the rest of configuration.

Pulled from `opae-sdk` branch `release/1.3.7` (which had the old pre-submodule
configuration) here: https://github.com/OPAE/opae-sdk/commit/babc1c9d67d5b509ec9635c9fe279d5651b4751f

Signed-off-by: Marroquin, Asgard <asgard.marroquin@intel.com>