### PR TITLE
pyopae: update pybind11 version to 2.6

### DIFF
--- a/pyopae/CMakeLists.txt
+++ b/pyopae/CMakeLists.txt
@@ -48,7 +48,7 @@ set(PYOPAE_SRC
 
 opae_external_project_add(PROJECT_NAME pybind11
                           GIT_URL https://github.com/pybind/pybind11.git
-                          GIT_TAG v2.4.3
+                          GIT_TAG v2.6.0
                           )
 
 opae_add_module_library(TARGET _opae


### PR DESCRIPTION
Primary motivation for this is to take advantage #ifdef in pybind11 to
only call a now deprecated function, PyEval_InitThreads if the version of
Python is less than 3.9.