### PR TITLE
build: change OPAEExternal macros

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         apt-get: uuid-dev libjson-c-dev libhwloc-dev lcov
     - name: configure
-      run: mkdir ${{ github.workspace }}/.build && cd ${{ github.workspace }}/.build && cmake .. -DCMAKE_BUILD_TYPE=Debug -DOPAE_ENABLE_MOCK=ON -DOPAE_BUILD_TESTS=ON
+      run: mkdir ${{ github.workspace }}/.build && cd ${{ github.workspace }}/.build && cmake .. -DCMAKE_BUILD_TYPE=Debug -DOPAE_ENABLE_MOCK=ON -DOPAE_BUILD_TESTS=ON -DOPAE_PYTHON_VERSION=3
     - name: make
       run: cd ${{ github.workspace }}/.build && make -j
     - name: set hugepages

--- a/cmake/modules/OPAEExternal.cmake
+++ b/cmake/modules/OPAEExternal.cmake
@@ -92,6 +92,8 @@ macro(opae_external_project_add)
                 message(FATAL_ERROR "Build step for ${OPAE_EXTERNAL_PROJECT_ADD_PROJECT_NAME} failed: ${result}")
             endif(result)
         endif()
+        add_custom_target(${OPAE_EXTERNAL_PROJECT_ADD_PROJECT_NAME}-fetch
+        )
     endif (${OPAE_EXTERNAL_PROJECT_ADD_DEFER})
 
     set(src_dir

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -31,6 +31,9 @@ if(OPAE_BUILD_TESTS)
                               GIT_URL https://github.com/OPAE/opae-test.git
                               GIT_TAG ${OPAE_TEST_TAG}
                               PRESERVE_REPOS ${OPAE_PRESERVE_REPOS})
+    set(DEFER "")
+else(OPAE_BUILD_TESTS)
+    set(DEFER DEFER)
 endif(OPAE_BUILD_TESTS)
 
 if(OPAE_BUILD_SIM)
@@ -39,3 +42,19 @@ if(OPAE_BUILD_SIM)
                               GIT_TAG ${OPAE_SIM_TAG}
                               PRESERVE_REPOS ${OPAE_PRESERVE_REPOS})
 endif(OPAE_BUILD_SIM)
+
+if(OPAE_BUILD_LIBOPAE_PY)
+    if(${CMAKE_VERSION} VERSION_LESS "3.4.0" AND ${PYTHONLIBS_VERSION_STRING} VERSION_LESS "3.9.0")
+        set(PYBIND11_TAG "v2.4.3")
+    else()
+    # Otherwise, pull recent pybind11 tag to enable Python 3.9 support.
+        set(PYBIND11_TAG "v2.6.0")
+    endif()
+    message(STATUS "Using pybind11 ${PYBIND11_TAG}")
+    opae_external_project_add(PROJECT_NAME pybind11
+                              GIT_URL https://github.com/pybind/pybind11.git
+                              GIT_TAG "${PYBIND11_TAG}"
+                              ${DEFER}
+    )
+
+endif(OPAE_BUILD_LIBOPAE_PY)

--- a/pyopae/CMakeLists.txt
+++ b/pyopae/CMakeLists.txt
@@ -46,20 +46,7 @@ set(PYOPAE_SRC
     pysysobject.cpp
 )
 
-if(${CMAKE_VERSION} VERSION_LESS "3.4.0" AND ${PYTHONLIBS_VERSION_STRING} VERSION_LESS "3.9.0")
-    set(PYBIND11_TAG "v2.4.3")
-else()
-# Otherwise, pull recent pybind11 tag to enable Python 3.9 support.
-    set(PYBIND11_TAG "v2.6.0")
-endif()
-message(STATUS "Using pybind11 ${PYBIND11_TAG}")
 
-
-opae_external_project_add(PROJECT_NAME pybind11
-                          GIT_URL https://github.com/pybind/pybind11.git
-                          GIT_TAG "${PYBIND11_TAG}"
-                          DEFER
-                          )
 
 opae_add_module_library(TARGET _opae
     SOURCE ${PYOPAE_SRC}

--- a/pyopae/CMakeLists.txt
+++ b/pyopae/CMakeLists.txt
@@ -58,6 +58,7 @@ message(STATUS "Using pybind11 ${PYBIND11_TAG}")
 opae_external_project_add(PROJECT_NAME pybind11
                           GIT_URL https://github.com/pybind/pybind11.git
                           GIT_TAG "${PYBIND11_TAG}"
+                          DEFER
                           )
 
 opae_add_module_library(TARGET _opae

--- a/pyopae/CMakeLists.txt
+++ b/pyopae/CMakeLists.txt
@@ -79,6 +79,8 @@ set_target_properties(_opae
     ${LIBRARY_OUTPUT_PATH}/python${OPAE_PYTHON_VERSION}/opae/fpga
 )
 
+opae_target_depends_external(_opae pybind11)
+
 add_custom_command(TARGET _opae
     POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy

--- a/tests/pyopae/CMakeLists.txt
+++ b/tests/pyopae/CMakeLists.txt
@@ -69,6 +69,8 @@ if (SUPPORTS_EMBEDDED_PYTHON)
             ${libjson-c_LIBRARIES}
             ${PYTHON_LIBRARIES})
 
+    opae_target_depends_external(test_pyopae pybind11)
+
     macro(add_pyopae_test pytest)
         add_custom_command(TARGET test_pyopae
            POST_BUILD


### PR DESCRIPTION
* Change opae_external_project_add macro
  * Add DEFER option to opae_external_project_add macro
    * Without DEFER, behavior is unchanged from before where external
      projects are fetched at configure time
    * With DEFER, behavior changes to adding a fetch target that fetches
      the external project at build time
      * Add a custom command to execute the steps it was doing before in
        execute_process.
      * Add a fetch target that depends on the output of the custom command
  * Add opae_target_depends_external macro to add a dependency between a
  target and a the fetch target.
  * These changes make it so external projects are downloaded at build
  time rather than configure time. This also optimizes configure/build
  so external projects are only downloaded when making all targets or
  making a target that depends on the external.
* move adding pybind11 as external to external/CMakeLists.txt
* set CI Python version to 3