### PR TITLE
libopae-c: build libopae-c-ase only when ase is enabled

### DIFF
--- a/libopae-c/CMakeLists.txt
+++ b/libopae-c/CMakeLists.txt
@@ -43,6 +43,7 @@ opae_add_shared_library(TARGET opae-c
     COMPONENT opaeclib
 )
 
+if(BUILD_ASE)
 set(SRC_ASE
     pluginmgr.c
     api-shell.c
@@ -62,3 +63,4 @@ opae_add_shared_library(TARGET opae-c-ase
     SOVERSION ${OPAE_VERSION_MAJOR}
     COMPONENT opaecsimlib
 )
+endif()


### PR DESCRIPTION
Signed-off-by: Martin Hundebøll <mhu@silicom.dk>