### PR TITLE
fix codingstyle for cpp files

### DIFF
--- a/include/opae/cxx/core/errors.h
+++ b/include/opae/cxx/core/errors.h
@@ -27,6 +27,7 @@
 
 #include <opae/cxx/core/token.h>
 #include <opae/types_enum.h>
+
 #include <memory>
 
 namespace opae {

--- a/include/opae/cxx/core/events.h
+++ b/include/opae/cxx/core/events.h
@@ -25,11 +25,10 @@
 // POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
-#include <memory>
-
+#include <opae/cxx/core/handle.h>
 #include <opae/types_enum.h>
 
-#include <opae/cxx/core/handle.h>
+#include <memory>
 
 namespace opae {
 namespace fpga {

--- a/include/opae/cxx/core/except.h
+++ b/include/opae/cxx/core/except.h
@@ -24,10 +24,10 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 #pragma once
+#include <opae/types_enum.h>
+
 #include <cstdint>
 #include <exception>
-
-#include <opae/types_enum.h>
 
 namespace opae {
 namespace fpga {

--- a/include/opae/cxx/core/handle.h
+++ b/include/opae/cxx/core/handle.h
@@ -24,12 +24,12 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 #pragma once
-#include <memory>
-#include <vector>
-
 #include <opae/cxx/core/token.h>
 #include <opae/enum.h>
 #include <opae/types.h>
+
+#include <memory>
+#include <vector>
 
 namespace opae {
 namespace fpga {

--- a/include/opae/cxx/core/properties.h
+++ b/include/opae/cxx/core/properties.h
@@ -24,13 +24,13 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 #pragma once
+#include <opae/cxx/core/pvalue.h>
+#include <opae/properties.h>
+
 #include <iostream>
 #include <map>
 #include <memory>
 #include <vector>
-
-#include <opae/cxx/core/pvalue.h>
-#include <opae/properties.h>
 
 namespace opae {
 namespace fpga {

--- a/include/opae/cxx/core/pvalue.h
+++ b/include/opae/cxx/core/pvalue.h
@@ -28,6 +28,7 @@
 #include <opae/properties.h>
 #include <opae/utils.h>
 #include <uuid/uuid.h>
+
 #include <algorithm>
 #include <array>
 #include <cstring>

--- a/include/opae/cxx/core/shared_buffer.h
+++ b/include/opae/cxx/core/shared_buffer.h
@@ -24,16 +24,16 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 #pragma once
+#include <opae/buffer.h>
+#include <opae/cxx/core/except.h>
+#include <opae/cxx/core/handle.h>
+
 #include <chrono>
 #include <cstdint>
 #include <initializer_list>
 #include <memory>
 #include <thread>
 #include <vector>
-
-#include <opae/buffer.h>
-#include <opae/cxx/core/except.h>
-#include <opae/cxx/core/handle.h>
 
 namespace opae {
 namespace fpga {

--- a/include/opae/cxx/core/sysobject.h
+++ b/include/opae/cxx/core/sysobject.h
@@ -24,12 +24,12 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 #pragma once
-#include <memory>
-#include <vector>
-
 #include <opae/cxx/core/handle.h>
 #include <opae/cxx/core/token.h>
 #include <opae/types.h>
+
+#include <memory>
+#include <vector>
 
 namespace opae {
 namespace fpga {

--- a/include/opae/cxx/core/token.h
+++ b/include/opae/cxx/core/token.h
@@ -24,13 +24,13 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 #pragma once
-#include <memory>
-#include <vector>
-
 #include <opae/access.h>
 #include <opae/cxx/core/properties.h>
 #include <opae/enum.h>
 #include <opae/types.h>
+
+#include <memory>
+#include <vector>
 
 namespace opae {
 namespace fpga {

--- a/include/opae/cxx/core/version.h
+++ b/include/opae/cxx/core/version.h
@@ -24,9 +24,9 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 #pragma once
-#include <string>
-
 #include <opae/types.h>
+
+#include <string>
 
 namespace opae {
 namespace fpga {

--- a/libopaecxx/samples/hello_fpga-1.cpp
+++ b/libopaecxx/samples/hello_fpga-1.cpp
@@ -26,19 +26,18 @@
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif  // HAVE_CONFIG_H
-#include <algorithm>
-#include <chrono>
-#include <iostream>
-#include <string>
-#include <thread>
-
-#include <uuid/uuid.h>
-
 #include <opae/cxx/core/handle.h>
 #include <opae/cxx/core/properties.h>
 #include <opae/cxx/core/shared_buffer.h>
 #include <opae/cxx/core/token.h>
 #include <opae/cxx/core/version.h>
+#include <uuid/uuid.h>
+
+#include <algorithm>
+#include <chrono>
+#include <iostream>
+#include <string>
+#include <thread>
 
 using namespace opae::fpga::types;
 

--- a/libopaecxx/src/events.cpp
+++ b/libopaecxx/src/events.cpp
@@ -24,10 +24,9 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include <opae/event.h>
-
 #include <opae/cxx/core/events.h>
 #include <opae/cxx/core/except.h>
+#include <opae/event.h>
 
 namespace opae {
 namespace fpga {

--- a/libopaecxx/src/except.cpp
+++ b/libopaecxx/src/except.cpp
@@ -23,14 +23,13 @@
 // CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
+#include <opae/cxx/core/except.h>
+#include <opae/utils.h>
+
 #include <cerrno>
 #include <cstring>
 #include <iostream>
 #include <sstream>
-
-#include <opae/utils.h>
-
-#include <opae/cxx/core/except.h>
 
 namespace opae {
 namespace fpga {

--- a/libopaecxx/src/shared_buffer.cpp
+++ b/libopaecxx/src/shared_buffer.cpp
@@ -23,10 +23,10 @@
 // CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
+#include <opae/cxx/core/shared_buffer.h>
+
 #include <algorithm>
 #include <cstring>
-
-#include <opae/cxx/core/shared_buffer.h>
 #include <exception>
 
 namespace opae {

--- a/libopaecxx/src/token.cpp
+++ b/libopaecxx/src/token.cpp
@@ -26,6 +26,7 @@
 #include <opae/cxx/core/except.h>
 #include <opae/cxx/core/token.h>
 #include <opae/utils.h>
+
 #include <algorithm>
 
 namespace opae {


### PR DESCRIPTION
Run clang-format to auto-fix coding style violations.
The changes are all about reordering #includes to meet Google style
coding format.