### PR TITLE
cmake: add options/guards for building vfio/uio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,9 +135,11 @@ if (OPAE_BUILD_LIBOPAEVFIO)
     )
 
     if (VFIO_CHECK)
-        set(PLATFORM_SUPPORTS_VFIO TRUE CACHE BOOL "Platform supports vfio driver")
+        set(PLATFORM_SUPPORTS_VFIO TRUE CACHE BOOL "Platform supports vfio driver" FORCE)
+        message(STATUS
+            "Compatible VFIO headers found")
     else(VFIO_CHECK)
-        set(PLATFORM_SUPPORTS_VFIO FALSE CACHE BOOL "Platform supports vfio driver")
+        set(PLATFORM_SUPPORTS_VFIO FALSE CACHE BOOL "Platform supports vfio driver" FORCE)
         message(WARNING
             "Could not compile VFIO.
             This most likely means that kernel( version >= 4.6) headers aren't installed.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,23 +121,30 @@ if(OPAE_BUILD_SIM)
     mark_as_advanced(OPAE_SIM_TAG)
 endif(OPAE_BUILD_SIM)
 
+if (OPAE_BUILD_PLUGIN_VFIO AND NOT OPAE_BUILD_LIBOPAEVFIO)
+    message(STATUS
+        "Enabling vfio plugin automatically enables libopaevfio")
+    set(OPAE_BUILD_LIBOPAEVFIO ON)
+endif (OPAE_BUILD_PLUGIN_VFIO AND NOT OPAE_BUILD_LIBOPAEVFIO)
 
-try_compile(VFIO_CHECK
-    ${CMAKE_BINARY_DIR}
-    ${CMAKE_SOURCE_DIR}/libopaevfio/vfiocheck.c
-    OUTPUT_VARIABLE TRY_COMPILE_OUTPUT
-)
+if (OPAE_BUILD_LIBOPAEVFIO)
+    try_compile(VFIO_CHECK
+        ${CMAKE_BINARY_DIR}
+        ${CMAKE_SOURCE_DIR}/libopaevfio/vfiocheck.c
+        OUTPUT_VARIABLE TRY_COMPILE_OUTPUT
+    )
 
-if (VFIO_CHECK)
-    set(PLATFORM_SUPPORTS_VFIO TRUE CACHE BOOL "Platform supports vfio driver")
-else(VFIO_CHECK)
-    set(PLATFORM_SUPPORTS_VFIO FALSE CACHE BOOL "Platform supports vfio driver")
-    message(WARNING
-        "Could not compile VFIO.
-        This most likely means that kernel( version >= 4.6) headers aren't installed.
-        See errors in platform_vfio_errors.txt")
-    file(WRITE ${CMAKE_BINARY_DIR}/platform_vfio_errors.txt ${TRY_COMPILE_OUTPUT})
-endif(VFIO_CHECK)
+    if (VFIO_CHECK)
+        set(PLATFORM_SUPPORTS_VFIO TRUE CACHE BOOL "Platform supports vfio driver")
+    else(VFIO_CHECK)
+        set(PLATFORM_SUPPORTS_VFIO FALSE CACHE BOOL "Platform supports vfio driver")
+        message(WARNING
+            "Could not compile VFIO.
+            This most likely means that kernel( version >= 4.6) headers aren't installed.
+            See errors in platform_vfio_errors.txt")
+        file(WRITE ${CMAKE_BINARY_DIR}/platform_vfio_errors.txt ${TRY_COMPILE_OUTPUT})
+    endif(VFIO_CHECK)
+endif (OPAE_BUILD_LIBOPAEVFIO)
 
 ############################################################################
 ## Add Subdirectories ######################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin CACHE PATH "Exe Build directo
 set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib CACHE PATH "Lib Build directory" FORCE)
 
 ############################################################################
-## Conditional Build Steps #################################################
+## Conditional Build Steps and Features ####################################
 ############################################################################
 option(OPAE_BUILD_LIBOPAE_CXX "Enable building of C++ bindings around libopae-c." ON)
 mark_as_advanced(OPAE_BUILD_LIBOPAE_CXX)
@@ -99,6 +99,15 @@ mark_as_advanced(OPAE_ENABLE_MOCK)
 option(OPAE_BUILD_SIM "Enable building of the AFU simulation environment" OFF)
 mark_as_advanced(OPAE_BUILD_SIM)
 
+option(OPAE_BUILD_LIBOPAEVFIO "Enable building of the opaevfio library" ON)
+mark_as_advanced(OPAE_BUILD_LIBOPAEVFIO)
+
+option(OPAE_BUILD_PLUGIN_VFIO "Enable building of the vfio plugin module" ON)
+mark_as_advanced(OPAE_BUILD_PLUGIN_VFIO)
+
+option(OPAE_BUILD_LIBOPAEUIO "Enable building of the opaeuio library" ON)
+mark_as_advanced(OPAE_BUILD_LIBOPAEUIO)
+
 option(OPAE_PRESERVE_REPOS "Disable refresh of external repos" OFF)
 mark_as_advanced(OPAE_PRESERVE_REPOS)
 
@@ -112,6 +121,24 @@ if(OPAE_BUILD_SIM)
     mark_as_advanced(OPAE_SIM_TAG)
 endif(OPAE_BUILD_SIM)
 
+
+try_compile(VFIO_CHECK
+    ${CMAKE_BINARY_DIR}
+    ${CMAKE_SOURCE_DIR}/libopaevfio/vfiocheck.c
+    OUTPUT_VARIABLE TRY_COMPILE_OUTPUT
+)
+
+if (VFIO_CHECK)
+    set(PLATFORM_SUPPORTS_VFIO TRUE CACHE BOOL "Platform supports vfio driver")
+else(VFIO_CHECK)
+    set(PLATFORM_SUPPORTS_VFIO FALSE CACHE BOOL "Platform supports vfio driver")
+    message(WARNING
+        "Could not compile VFIO.
+        This most likely means that kernel( version >= 4.6) headers aren't installed.
+        See errors in platform_vfio_errors.txt")
+    file(WRITE ${CMAKE_BINARY_DIR}/platform_vfio_errors.txt ${TRY_COMPILE_OUTPUT})
+endif(VFIO_CHECK)
+
 ############################################################################
 ## Add Subdirectories ######################################################
 ############################################################################
@@ -119,8 +146,15 @@ endif(OPAE_BUILD_SIM)
 opae_add_subdirectory(external)
 opae_add_subdirectory(libopaemem)
 opae_add_subdirectory(libopae-c)
-opae_add_subdirectory(libopaeuio)
-opae_add_subdirectory(libopaevfio)
+
+if (OPAE_BUILD_LIBOPAEUIO)
+    opae_add_subdirectory(libopaeuio)
+endif()
+
+if (OPAE_BUILD_LIBOPAEVFIO AND PLATFORM_SUPPORTS_VFIO)
+    opae_add_subdirectory(libopaevfio)
+endif()
+
 opae_add_subdirectory(libbitstream)
 opae_add_subdirectory(plugins)
 

--- a/libopaevfio/CMakeLists.txt
+++ b/libopaevfio/CMakeLists.txt
@@ -24,31 +24,18 @@
 ## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 ## POSSIBILITY OF SUCH DAMAGE.
 
-try_compile(PLATFORM_SUPPORTS_VFIO
-    ${CMAKE_CURRENT_BINARY_DIR}
-    ${CMAKE_CURRENT_SOURCE_DIR}/vfiocheck.c
-    OUTPUT_VARIABLE TRY_COMPILE_OUTPUT
+opae_add_shared_library(TARGET opaevfio
+    SOURCE opaevfio.c
+    LIBS
+        ${CMAKE_THREAD_LIBS_INIT}
+        opaemem
+    VERSION ${OPAE_VERSION}
+    SOVERSION ${OPAE_VERSION_MAJOR}
+    COMPONENT vfiolib
 )
 
-if (PLATFORM_SUPPORTS_VFIO)
-    set(PLATFORM_SUPPORTS_VFIO TRUE CACHE BOOL "Platform supports vfio driver")
-    opae_add_shared_library(TARGET opaevfio
-        SOURCE opaevfio.c
-        LIBS
-            ${CMAKE_THREAD_LIBS_INIT}
-            opaemem
-        VERSION ${OPAE_VERSION}
-        SOVERSION ${OPAE_VERSION_MAJOR}
-        COMPONENT vfiolib
-    )
-
-    opae_add_executable(TARGET opaevfiotest
-        SOURCE opaevfiotest.c
-        LIBS opaevfio
-        COMPONENT vfiotest
-    )
-else(PLATFORM_SUPPORTS_VFIO)
-    message(WARNING
-        "Could not compile VFIO. See errors in platform_vfio_errors.txt")
-    file(WRITE ${CMAKE_BINARY_DIR}/platform_vfio_errors.txt ${TRY_COMPILE_OUTPUT})
-endif(PLATFORM_SUPPORTS_VFIO)
+opae_add_executable(TARGET opaevfiotest
+    SOURCE opaevfiotest.c
+    LIBS opaevfio
+    COMPONENT vfiotest
+)

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -26,4 +26,12 @@
 
 add_subdirectory(xfpga)
 add_subdirectory(xfpga/metrics/bmc)
-add_subdirectory(vfio)
+
+if (OPAE_BUILD_PLUGIN_VFIO AND PLATFORM_SUPPORTS_VFIO)
+    if (OPAE_BUILD_LIBOPAEVFIO)
+        add_subdirectory(vfio)
+    else()
+        message(WARNING
+            "Must enable 'OPAE_BUILD_LIBOPAEVFIO' to build vfio plugin")
+    endif()
+endif()


### PR DESCRIPTION
* Add two compile options for enabling/disabling building of:
  * libopaevfio
  * libopaeuio
  * libopae-v (in plugins/vfio)
* Move vfio compile check to top CMakeLists and only check if
  libopaevfio is enabled.
* Add a little more information about vfio check failure.