### PR TITLE
cmake: fix path to vfiocheck.c

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ endif (OPAE_BUILD_PLUGIN_VFIO AND NOT OPAE_BUILD_LIBOPAEVFIO)
 if (OPAE_BUILD_LIBOPAEVFIO)
     try_compile(VFIO_CHECK
         ${CMAKE_BINARY_DIR}
-        ${CMAKE_CURRENT_SOURCE_DIR}/libopaevfio/vfiocheck.c
+        ${OPAE_LIBS_ROOT}/libopaevfio/vfiocheck.c
         OUTPUT_VARIABLE TRY_COMPILE_OUTPUT
     )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ endif (OPAE_BUILD_PLUGIN_VFIO AND NOT OPAE_BUILD_LIBOPAEVFIO)
 if (OPAE_BUILD_LIBOPAEVFIO)
     try_compile(VFIO_CHECK
         ${CMAKE_BINARY_DIR}
-        ${CMAKE_SOURCE_DIR}/libopaevfio/vfiocheck.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/libopaevfio/vfiocheck.c
         OUTPUT_VARIABLE TRY_COMPILE_OUTPUT
     )
 


### PR DESCRIPTION
When opae-libs is added as a subdirectory (like in opae-sdk) then
CMAKE_SOURCE_DIR is the root of the parent repository. Changing it to
CMAKE_CURRENT_SOURCE_DIR makes it relative to this CMakeLists.txt.