### PR TITLE
cmake: set min. version to 3.10, fix warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@
 ## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 ## POSSIBILITY OF SUCH DAMAGE.
 
-cmake_minimum_required(VERSION 3.6.0)
+cmake_minimum_required(VERSION 3.10)
 project(opae-libs)
 
 set(OPAE_VERSION_LOCAL   "" CACHE STRING "OPAE local version")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@
 ## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 ## POSSIBILITY OF SUCH DAMAGE.
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.6.0)
 project(opae-libs)
 
 set(OPAE_VERSION_LOCAL   "" CACHE STRING "OPAE local version")

--- a/cmake/modules/OPAEExternal.cmake
+++ b/cmake/modules/OPAEExternal.cmake
@@ -25,7 +25,7 @@
 ## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 ## POSSIBILITY OF SUCH DAMAGE
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 3.10)
 
 macro(opae_external_project_add)
     set(options EXCLUDE_FROM_ALL NO_ADD_SUBDIRECTORY DEFER)
@@ -44,7 +44,7 @@ macro(opae_external_project_add)
     set(download_dir
         ${CMAKE_CURRENT_BINARY_DIR}/${OPAE_EXTERNAL_PROJECT_ADD_PROJECT_NAME}/download)
     file(WRITE ${download_dir}/CMakeLists.txt
-        "cmake_minimum_required(VERSION 2.8.12)\n"
+        "cmake_minimum_required(VERSION 3.10)\n"
         "project(${OPAE_EXTERNAL_PROJECT_ADD_PROJECT_NAME}-download)\n"
         "include(ExternalProject)\n"
         "ExternalProject_Add(${OPAE_EXTERNAL_PROJECT_ADD_PROJECT_NAME}\n"

--- a/cmake/modules/OPAETest.cmake
+++ b/cmake/modules/OPAETest.cmake
@@ -28,7 +28,7 @@
 check_cxx_compiler_flag("-Wno-sign-compare" CXX_SUPPORTS_NO_SIGN_COMPARE)
 
 set(OPAE_TEST_LIBRARIES test_system fpga_db
-    CACHE LIST "OPAE test libs." FORCE)
+    CACHE INTERNAL "OPAE test libs." FORCE)
 
 function(opae_load_gtest)
     message(STATUS "Trying to fetch gtest through git...")
@@ -77,7 +77,7 @@ function(opae_load_gtest)
     set(GTEST_LIBRARIES "libgtest"
         CACHE PATH "GTest test lib." FORCE)
     set(GTEST_BOTH_LIBRARIES libgtest_main libgtest
-        CACHE LIST "GTest both libs." FORCE) 
+        CACHE INTERNAL "GTest both libs." FORCE)
     set(GTEST_FOUND TRUE CACHE BOOL "GTest found?" FORCE)
 endfunction()
 

--- a/cmake/modules/OPAETest.cmake
+++ b/cmake/modules/OPAETest.cmake
@@ -99,7 +99,8 @@ function(opae_test_add)
         PROPERTIES
             CXX_STANDARD 11
             CXX_STANDARD_REQUIRED YES
-            CXX_EXTENSIONS NO)
+            CXX_EXTENSIONS NO
+            ENABLE_EXPORTS ON)
     target_compile_definitions(${OPAE_TEST_ADD_TARGET}
         PRIVATE
             HAVE_CONFIG_H=1)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -24,7 +24,7 @@
 ## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 ## POSSIBILITY OF SUCH DAMAGE.
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 if(OPAE_BUILD_TESTS)
     opae_external_project_add(PROJECT_NAME opae-test

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,7 +24,7 @@
 ## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 ## POSSIBILITY OF SUCH DAMAGE.
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 3.10)
 project(tests)
 
 if(${GTest_FOUND})


### PR DESCRIPTION
* set cmake minimum version to 3.10
* change `LIST` cmake type to `INTERNAL` to resolve warnings about
implicit conversion to `STRING`
* set `ENABLE_EXPORTS` to ON for test executables.
  The test system uses `dladdr` for aid in injecting errors for negative tests
  but the use of `dladdr` will not work with newer versions of cmake unless
  explicitly setting `ENABLE_EXPORTS` to `ON`.