### PR TITLE
opae-libs: Add recursive glob support to SYSOBJECT API

### DIFF
--- a/plugins/xfpga/sysfs.c
+++ b/plugins/xfpga/sysfs.c
@@ -2312,7 +2312,7 @@ fpga_result make_sysfs_object(char *sysfspath, const char *name,
 	if (flags & FPGA_OBJECT_GLOB) {
 
 		// search for pattern /**/
-		char* p = strstr(sysfspath, "/**/");
+		p = strstr(sysfspath, "/**/");
 		while (p!= NULL) {
 			p++;
 			found++;

--- a/plugins/xfpga/sysfs.c
+++ b/plugins/xfpga/sysfs.c
@@ -2325,7 +2325,7 @@ fpga_result make_sysfs_object(char *sysfspath, const char *name,
 					return FPGA_INVALID_PARAM;
 				}
 				ptr = strstr(ptr, "/**/");
-			};
+			}
 			found = 0;
 
 			// Prefix substring

--- a/plugins/xfpga/sysfs.c
+++ b/plugins/xfpga/sysfs.c
@@ -2323,7 +2323,8 @@ fpga_result make_sysfs_object(char *sysfspath, const char *name,
 			// while loop depth 5
 			while (resurse_depth) {
 				memset(full_path, 0, sizeof(full_path));
-				strncat(pattern, "*/", strlen("*/"));
+				len = strnlen(pattern, SYSFS_PATH_MAX - 1);
+				strncat(pattern, "*/", SYSFS_PATH_MAX - len);
 
 				if (snprintf(full_path, SYSFS_PATH_MAX,
 					"%s%s%s", prefix_path, pattern, p + 3) < 0) {

--- a/plugins/xfpga/sysfs.c
+++ b/plugins/xfpga/sysfs.c
@@ -2289,7 +2289,8 @@ out_err:
 }
 
 
-#define MAX_SYSOBJECT_GLOB 128
+#define MAX_SYSOBJECT_GLOB 128 
+#define MAX_SYSOBJECT_GLOB_RESURSIVE_DEPTH 5
 fpga_result make_sysfs_object(char *sysfspath, const char *name,
 			      fpga_object *object, int flags,
 			      fpga_handle handle)
@@ -2302,8 +2303,53 @@ fpga_result make_sysfs_object(char *sysfspath, const char *name,
 	char *object_paths[MAX_SYSOBJECT_GLOB] = { NULL };
 	size_t found = 0;
 	size_t len;
+	int resurse_depth = MAX_SYSOBJECT_GLOB_RESURSIVE_DEPTH;
+	char pattern[SYSFS_PATH_MAX] = { 0 };
+	char full_path[SYSFS_PATH_MAX] = { 0 };
+	char prefix_path[SYSFS_PATH_MAX] = { 0 };
 
 	if (flags & FPGA_OBJECT_GLOB) {
+
+		// Check "**"recursive pattern in sysfs path
+		if (strstr(sysfspath, "**")) {
+			char *p = strstr(sysfspath, "**/");
+			if (p == NULL)
+				return FPGA_INVALID_PARAM;
+
+			// Prefix substring
+			strncpy(prefix_path, sysfspath, p - sysfspath);
+			*(prefix_path + (p - sysfspath)) = '\0';
+
+			// while loop depth 5
+			while (resurse_depth) {
+				memset(full_path, 0, sizeof(full_path));
+				strncat(pattern, "*/", strlen("*/"));
+
+				if (snprintf(full_path, SYSFS_PATH_MAX,
+					"%s%s%s", prefix_path, pattern, p + 3) < 0) {
+					OPAE_ERR("snprintf buffer overflow");
+					return FPGA_EXCEPTION;
+				}
+
+				res = opae_glob_paths(full_path, MAX_SYSOBJECT_GLOB,
+					object_paths, &found);
+
+				resurse_depth--;
+
+				if (res) {
+					continue;
+				}
+
+				if (found > 0) {
+					len = strnlen(object_paths[0], SYSFS_PATH_MAX - 1);
+					memcpy(sysfspath, object_paths[0], len);
+					sysfspath[len] = '\0';
+					break;
+				}
+
+			} // end
+		}
+
 		res = opae_glob_paths(sysfspath, MAX_SYSOBJECT_GLOB,
 				      object_paths, &found);
 		if (res) {

--- a/plugins/xfpga/sysfs.c
+++ b/plugins/xfpga/sysfs.c
@@ -2311,8 +2311,8 @@ fpga_result make_sysfs_object(char *sysfspath, const char *name,
 	if (flags & FPGA_OBJECT_GLOB) {
 
 		// Check "**"recursive pattern in sysfs path
-		if (strstr(sysfspath, "**")) {
-			char *p = strstr(sysfspath, "**/");
+		if (strstr(sysfspath, "/**/")) {
+			char *p = strstr(sysfspath, "/**/");
 			if (p == NULL)
 				return FPGA_INVALID_PARAM;
 
@@ -2327,7 +2327,7 @@ fpga_result make_sysfs_object(char *sysfspath, const char *name,
 				strncat(pattern, "*/", SYSFS_PATH_MAX - len);
 
 				if (snprintf(full_path, SYSFS_PATH_MAX,
-					"%s%s%s", prefix_path, pattern, p + 3) < 0) {
+					"%s%s%s", prefix_path, pattern, p + 4) < 0) {
 					OPAE_ERR("snprintf buffer overflow");
 					return FPGA_EXCEPTION;
 				}

--- a/plugins/xfpga/sysfs.c
+++ b/plugins/xfpga/sysfs.c
@@ -2307,27 +2307,26 @@ fpga_result make_sysfs_object(char *sysfspath, const char *name,
 	char pattern[SYSFS_PATH_MAX] = { 0 };
 	char full_path[SYSFS_PATH_MAX] = { 0 };
 	char prefix_path[SYSFS_PATH_MAX] = { 0 };
-	char* p = NULL;
 
 	if (flags & FPGA_OBJECT_GLOB) {
 
-		// search for pattern /**/
-		p = strstr(sysfspath, "/**/");
-		while (p!= NULL) {
-			p++;
-			found++;
-			if (found > 1) {
-				return FPGA_INVALID_PARAM;
-			}
-			p = strstr(p, "/**/");
-		};
-
-		found = 0;
 		// Check "**"recursive pattern in sysfs path
 		if (strstr(sysfspath, "/**/")) {
 			char *p = strstr(sysfspath, "/**/");
 			if (p == NULL)
 				return FPGA_INVALID_PARAM;
+
+			// search for multipule pattern "/**/"
+			char *ptr = p;
+			while (ptr != NULL) {
+				ptr++;
+				found++;
+				if (found > 1) {
+					return FPGA_INVALID_PARAM;
+				}
+				ptr = strstr(ptr, "/**/");
+			};
+			found = 0;
 
 			// Prefix substring
 			strncpy(prefix_path, sysfspath, p - sysfspath);

--- a/plugins/xfpga/sysfs.c
+++ b/plugins/xfpga/sysfs.c
@@ -2310,6 +2310,18 @@ fpga_result make_sysfs_object(char *sysfspath, const char *name,
 
 	if (flags & FPGA_OBJECT_GLOB) {
 
+		// serach for search pattern /**/
+		char* p = strstr(sysfspath, "/**/");
+		while (p != NULL) {
+			p++;
+			found++;
+			p = strstr(p, "/**/");
+		};
+
+		if (found > 1) {
+			return FPGA_INVALID_PARAM;
+		}
+		found = 0;
 		// Check "**"recursive pattern in sysfs path
 		if (strstr(sysfspath, "/**/")) {
 			char *p = strstr(sysfspath, "/**/");

--- a/plugins/xfpga/sysfs.c
+++ b/plugins/xfpga/sysfs.c
@@ -2307,20 +2307,21 @@ fpga_result make_sysfs_object(char *sysfspath, const char *name,
 	char pattern[SYSFS_PATH_MAX] = { 0 };
 	char full_path[SYSFS_PATH_MAX] = { 0 };
 	char prefix_path[SYSFS_PATH_MAX] = { 0 };
+	char* p = NULL;
 
 	if (flags & FPGA_OBJECT_GLOB) {
 
-		// serach for search pattern /**/
+		// search for pattern /**/
 		char* p = strstr(sysfspath, "/**/");
-		while (p != NULL) {
+		while (p!= NULL) {
 			p++;
 			found++;
+			if (found > 1) {
+				return FPGA_INVALID_PARAM;
+			}
 			p = strstr(p, "/**/");
 		};
 
-		if (found > 1) {
-			return FPGA_INVALID_PARAM;
-		}
 		found = 0;
 		// Check "**"recursive pattern in sysfs path
 		if (strstr(sysfspath, "/**/")) {

--- a/tests/xfpga/test_sysfs_c.cpp
+++ b/tests/xfpga/test_sysfs_c.cpp
@@ -846,6 +846,33 @@ TEST_P(sysfs_c_mock_p, fpga_sysfs_07) {
 	}
 }
 
+/*
+* @test      sysfs
+* @brief     Tests: make_sysfs_object
+ @details    When passed with invalid sysfs path with multipule "**" to
+*            make_sysfs_object functin recursively walks
+*            in SYSFS directory hierarchy and returns error <br>
+*            Then the return value FPGA_INVALID_PARAM <br>
+*/
+TEST_P(sysfs_c_mock_p, fpga_sysfs_08) {
+	_fpga_token *tok = static_cast<_fpga_token *>(tokens_[0]);
+	fpga_object object = NULL;
+	char full_path[SYSFS_PATH_MAX] = { 0 };
+	fpga_result result;
+
+	if (snprintf(full_path, SYSFS_PATH_MAX,
+		"%s%s", tok->sysfspath, "/dfl*/*spi*/spi_master/spi*/**/security/**/*flash_count") < 0) {
+		OPAE_ERR("snprintf buffer overflow");
+	}
+
+	result = make_sysfs_object(full_path, "*flash_count", &object,
+		FPGA_OBJECT_GLOB, 0);
+	EXPECT_EQ(result, FPGA_INVALID_PARAM);
+
+	if (result == FPGA_OK) {
+		EXPECT_EQ(xfpga_fpgaDestroyObject(&object), FPGA_OK);
+	}
+}
 INSTANTIATE_TEST_CASE_P(sysfs_c, sysfs_c_mock_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));
 

--- a/tests/xfpga/test_sysfs_c.cpp
+++ b/tests/xfpga/test_sysfs_c.cpp
@@ -792,6 +792,60 @@ TEST_P(sysfs_c_mock_p, fpga_sysfs_05) {
 }
 
 
+/*
+* @test      sysfs
+* @brief     Tests: make_sysfs_object
+ @details    When passed with valid sysfs path with "**" to
+*            make_sysfs_object functin recursively walks
+*            in SYSFS directory hierarchy and finds sysfs attributes <br>
+*            Then the return value FPGA_OK <br>
+*/
+
+TEST_P(sysfs_c_mock_p, fpga_sysfs_06) {
+	_fpga_token *tok = static_cast<_fpga_token *>(tokens_[0]);
+	fpga_object object ;
+	char full_path[SYSFS_PATH_MAX] = { 0 };
+
+	if (snprintf(full_path, SYSFS_PATH_MAX,
+		"%s%s", tok->sysfspath, "/dfl*/*spi*/spi_master/spi*/**/security/*flash_count") < 0) {
+		OPAE_ERR("snprintf buffer overflow");
+	}
+
+	ASSERT_EQ(make_sysfs_object(full_path, "*flash_count", &object,
+		FPGA_OBJECT_GLOB, 0),
+		FPGA_OK);
+
+	EXPECT_EQ(xfpga_fpgaDestroyObject(&object), FPGA_OK);
+
+}
+/*
+* @test      sysfs
+* @brief     Tests: make_sysfs_object
+ @details    When passed with invalid sysfs path with "**" to
+*            make_sysfs_object functin recursively walks
+*            in SYSFS directory hierarchy and returns error <br>
+*            Then the return value FPGA_NOT_FOUND <br>
+*/
+TEST_P(sysfs_c_mock_p, fpga_sysfs_07) {
+	_fpga_token *tok = static_cast<_fpga_token *>(tokens_[0]);
+	fpga_object object = NULL;
+	char full_path[SYSFS_PATH_MAX] = { 0 };
+	fpga_result result;
+
+	if (snprintf(full_path, SYSFS_PATH_MAX,
+		"%s%s", tok->sysfspath, "/dfl*/*spi*/spi_master/spi*/**/security/*test_count") < 0) {
+		OPAE_ERR("snprintf buffer overflow");
+	}
+
+	result = make_sysfs_object(full_path, "*test_count", &object,
+		FPGA_OBJECT_GLOB, 0);
+	EXPECT_EQ(result, FPGA_NOT_FOUND);
+
+	if (result == FPGA_OK) {
+		EXPECT_EQ(xfpga_fpgaDestroyObject(&object), FPGA_OK);
+	}
+}
+
 INSTANTIATE_TEST_CASE_P(sysfs_c, sysfs_c_mock_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));
 


### PR DESCRIPTION
fpgaTokenGetObject() Recursively walks in SYSFS directory hierarchy
if SYS object API finds pattern “**” in path, recursive glob code walks in sub folders for SYSFS attribute.
Example:  Sysfs path :dfl*/*spi*/spi_master/spi*/**/security/*flash_count

 fpgaTokenGetObject(token, “dfl*/*spi*/spi_master/spi*/**/security/*flash_count"
, &fpga_object, FPGA_OBJECT_GLOB);

Object API function make_sysfs_object() search’s in sub sysfs directory’s recursively
dfl*/*spi*/spi_master/spi*/*/security/*flash_count
dfl*/*spi*/spi_master/spi*/*/*/security/*flash_count
dfl*/*spi*/spi_master/spi*/*/*/*/security/*flash_count

Signed-off-by: anandaravuri <ananda.ravuri@intel.com>