### PR TITLE
plugin: remove unused adapter entry points

### DIFF
--- a/libopae-c/adapter.h
+++ b/libopae-c/adapter.h
@@ -1,4 +1,4 @@
-// Copyright(c) 2018, Intel Corporation
+// Copyright(c) 2018-2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -216,10 +216,6 @@ typedef struct _opae_api_adapter_table {
 	// configuration functions
 	int (*initialize)(void);
 	int (*finalize)(void);
-
-	// first-level query
-	bool (*supports_device)(const char *device_type);
-	bool (*supports_host)(const char *hostname);
 
 } opae_api_adapter_table;
 

--- a/libopae-c/api-shell.c
+++ b/libopae-c/api-shell.c
@@ -508,14 +508,6 @@ static int opae_enumerate(const opae_api_adapter_table *adapter, void *context)
 	uint32_t i;
 	uint32_t space_remaining;
 
-	// TODO: accept/reject this adapter, based on device support
-	if (adapter->supports_device) {
-	}
-
-	// TODO: accept/reject this adapter, based on host support
-	if (adapter->supports_host) {
-	}
-
 	space_remaining = ctx->max_wrapped_tokens - ctx->num_wrapped_tokens;
 
 	if (ctx->wrapped_tokens && !space_remaining)

--- a/plugins/vfio/plugin.c
+++ b/plugins/vfio/plugin.c
@@ -1,4 +1,4 @@
-// Copyright(c) 2020, Intel Corporation
+// Copyright(c) 2020-2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -56,18 +56,6 @@ int __VFIO_API__ vfio_plugin_finalize(void)
 	return 0;
 }
 
-bool __VFIO_API__ vfio_plugin_supports_device(const char *device_type)
-{
-	(void)(device_type);
-	return true;
-}
-
-bool __VFIO_API__ vfio_plugin_supports_host(const char *hostname)
-{
-	(void)(hostname);
-	return true;
-}
-
 int __VFIO_API__ opae_plugin_configure(opae_api_adapter_table *adapter,
 				       const char *jsonConfig)
 {
@@ -113,12 +101,6 @@ int __VFIO_API__ opae_plugin_configure(opae_api_adapter_table *adapter,
 		dlsym(adapter->plugin.dl_handle, "vfio_plugin_initialize");
 	adapter->finalize =
 		dlsym(adapter->plugin.dl_handle, "vfio_plugin_finalize");
-
-	adapter->supports_device = dlsym(adapter->plugin.dl_handle,
-					 "vfio_plugin_supports_device");
-	adapter->supports_host =
-		dlsym(adapter->plugin.dl_handle, "vfio_plugin_supports_host");
-
 
 	return 0;
 }

--- a/plugins/xfpga/plugin.c
+++ b/plugins/xfpga/plugin.c
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2020, Intel Corporation
+// Copyright(c) 2018-2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -54,18 +54,6 @@ int __XFPGA_API__ xfpga_plugin_finalize(void)
 {
 	sysfs_finalize();
 	return 0;
-}
-
-bool __XFPGA_API__ xfpga_plugin_supports_device(const char *device_type)
-{
-	UNUSED_PARAM(device_type);
-	return true;
-}
-
-bool __XFPGA_API__ xfpga_plugin_supports_host(const char *hostname)
-{
-	UNUSED_PARAM(hostname);
-	return true;
 }
 
 int __XFPGA_API__ opae_plugin_configure(opae_api_adapter_table *adapter,
@@ -178,16 +166,6 @@ int __XFPGA_API__ opae_plugin_configure(opae_api_adapter_table *adapter,
 	adapter->fpgaGetUserClock =
 		dlsym(adapter->plugin.dl_handle, "xfpga_fpgaGetUserClock");
 
-	adapter->initialize =
-		dlsym(adapter->plugin.dl_handle, "xfpga_plugin_initialize");
-	adapter->finalize =
-		dlsym(adapter->plugin.dl_handle, "xfpga_plugin_finalize");
-
-	adapter->supports_device = dlsym(adapter->plugin.dl_handle,
-					 "xfpga_plugin_supports_device");
-	adapter->supports_host =
-		dlsym(adapter->plugin.dl_handle, "xfpga_plugin_supports_host");
-
 	adapter->fpgaGetNumMetrics =
 		dlsym(adapter->plugin.dl_handle, "xfpga_fpgaGetNumMetrics");
 
@@ -202,6 +180,11 @@ int __XFPGA_API__ opae_plugin_configure(opae_api_adapter_table *adapter,
 
 	adapter->fpgaGetMetricsThresholdInfo =
 		dlsym(adapter->plugin.dl_handle, "xfpga_fpgaGetMetricsThresholdInfo");
+
+	adapter->initialize =
+		dlsym(adapter->plugin.dl_handle, "xfpga_plugin_initialize");
+	adapter->finalize =
+		dlsym(adapter->plugin.dl_handle, "xfpga_plugin_finalize");
 
 	return 0;
 }

--- a/tests/opae-c/dummy_plugin.c
+++ b/tests/opae-c/dummy_plugin.c
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2019, Intel Corporation
+// Copyright(c) 2018-2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -40,18 +40,6 @@ int DUMMY_HIDDEN dummy_plugin_initialize(void)
 int DUMMY_HIDDEN dummy_plugin_finalize(void)
 {
 	return 0;
-}
-
-bool DUMMY_HIDDEN dummy_plugin_supports_device(const char *device_type)
-{
-	UNUSED_PARAM(device_type);
-	return true;
-}
-
-bool DUMMY_HIDDEN dummy_plugin_supports_host(const char *hostname)
-{
-	UNUSED_PARAM(hostname);
-	return true;
 }
 
 typedef struct _dummy_token {
@@ -150,8 +138,6 @@ int __attribute__((visibility("default"))) opae_plugin_configure(opae_api_adapte
 
         adapter->initialize = dummy_plugin_initialize;
 	adapter->finalize = NULL;
-	adapter->supports_device = dummy_plugin_supports_device;
-	adapter->supports_host = NULL;
 	adapter->fpgaEnumerate = dummy_plugin_fpgaEnumerate;
 	adapter->fpgaDestroyToken = dummy_plugin_fpgaDestroyToken;
 	adapter->fpgaOpen = dummy_plugin_fpgaOpen;

--- a/tests/xfpga/test_plugin_c.cpp
+++ b/tests/xfpga/test_plugin_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2017-2020, Intel Corporation
+// Copyright(c) 2017-2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -34,10 +34,8 @@ extern "C" {
 #include "types_int.h"
 #include "adapter.h"
 
-bool xfpga_plugin_supports_device(const char *device_type);
 int xfpga_plugin_initialize(void);
 int xfpga_plugin_finalize(void);
-bool xfpga_plugin_supports_host(const char *hostname);
 int opae_plugin_configure(opae_api_adapter_table *adapter,
 	const char *jsonConfig);
 }
@@ -140,18 +138,6 @@ protected:
 		return res;
 	}
 };
-
-/*
-* @test       plugin
-* @brief      Tests: xfpga_plugin_supports_device
-*                    xfpga_plugin_supports_host
- @details    When passed with valid argument,the fn returns true <br>
-*            When passed with invalid argument,the fn returns false <br>
-*/
-TEST_P(xfpga_plugin_c_p, test_plugin_1) {
-	EXPECT_EQ(xfpga_plugin_supports_device(NULL), true);
-	EXPECT_EQ(xfpga_plugin_supports_host(NULL), true);
-}
 
 /*
 * @test       plugin


### PR DESCRIPTION
Removes unused entry points supports_device() and supports_host()
from the adapter table.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>