### PR TITLE
logging: deprecate FPGA_MSG, FPGA_ERR, FPGA_DBG

### DIFF
--- a/include/opae/log.h
+++ b/include/opae/log.h
@@ -1,4 +1,4 @@
-// Copyright(c) 2018, Intel Corporation
+// Copyright(c) 2018-2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -81,18 +81,6 @@
 {	}
 #endif // LIBOPAE_DEBUG
 
-#ifndef FPGA_MSG
-#define FPGA_MSG OPAE_MSG
-#endif // FPGA_MSG
-
-#ifndef FPGA_ERR
-#define FPGA_ERR OPAE_ERR
-#endif // FPGA_ERR
-
-#ifndef FPGA_DBG
-#define FPGA_DBG OPAE_DBG
-#endif // FPGA_DBG
-
 /*
 * Logging functions
 */
@@ -103,10 +91,6 @@ enum opae_loglevel {
 };
 
 #define OPAE_DEFAULT_LOGLEVEL OPAE_LOG_ERROR
-
-#ifndef FPGA_DEFAULT_LOGLEVEL
-#define FPGA_DEFAULT_LOGLEVEL OPAE_DEFAULT_LOGLEVEL
-#endif // FPGA_DEFAULT_LOGLEVEL
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/opae-c/test_enum_c.cpp
+++ b/tests/opae-c/test_enum_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2017-2018, Intel Corporation
+// Copyright(c) 2017-2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -64,11 +64,11 @@ int port_info(mock_object * m, int request, va_list argp){
   UNUSED_PARAM(request);
   struct fpga_port_info *pinfo = va_arg(argp, struct fpga_port_info *);
   if (!pinfo) {
-  	FPGA_MSG("pinfo is NULL");
+  	OPAE_MSG("pinfo is NULL");
   	goto out_EINVAL;
   }
   if (pinfo->argsz != sizeof(*pinfo)) {
-  	FPGA_MSG("wrong structure size");
+  	OPAE_MSG("wrong structure size");
   	goto out_EINVAL;
   }
   pinfo->flags = 0;
@@ -100,11 +100,11 @@ int dfl_port_info(mock_object * m, int request, va_list argp){
   UNUSED_PARAM(request);
   struct dfl_fpga_port_info *pinfo = va_arg(argp, struct dfl_fpga_port_info *);
   if (!pinfo) {
-  	FPGA_MSG("pinfo is NULL");
+  	OPAE_MSG("pinfo is NULL");
   	goto out_EINVAL;
   }
   if (pinfo->argsz != sizeof(*pinfo)) {
-  	FPGA_MSG("wrong structure size");
+  	OPAE_MSG("wrong structure size");
   	goto out_EINVAL;
   }
   pinfo->flags = 0;

--- a/tests/opae-c/test_mmio_c.cpp
+++ b/tests/opae-c/test_mmio_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018, Intel Corporation
+// Copyright(c) 2018-2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -55,19 +55,19 @@ static int mmio_ioctl(mock_object * m, int request, va_list argp){
     UNUSED_PARAM(request);
     struct dfl_fpga_port_region_info *rinfo = va_arg(argp, struct dfl_fpga_port_region_info *);
     if (!rinfo) {
-      FPGA_MSG("rinfo is NULL");
+      OPAE_MSG("rinfo is NULL");
       goto out_EINVAL;
     }
     if (rinfo->argsz != sizeof(*rinfo)) {
-      FPGA_MSG("wrong structure size");
+      OPAE_MSG("wrong structure size");
       goto out_EINVAL;
     }
     if (rinfo->index > 1 ) {
-      FPGA_MSG("unsupported MMIO index");
+      OPAE_MSG("unsupported MMIO index");
       goto out_EINVAL;
     }
     if (rinfo->padding != 0) {
-      FPGA_MSG("unsupported padding");
+      OPAE_MSG("unsupported padding");
       goto out_EINVAL;
     }
     rinfo->flags = DFL_PORT_REGION_READ | DFL_PORT_REGION_WRITE | DFL_PORT_REGION_MMAP;

--- a/tests/opae-c/test_umsg_c.cpp
+++ b/tests/opae-c/test_umsg_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2020, Intel Corporation
+// Copyright(c) 2018-2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -56,11 +56,11 @@ int umsg_port_info(mock_object * m, int request, va_list argp){
     UNUSED_PARAM(request);
     struct fpga_port_info *pinfo = va_arg(argp, struct fpga_port_info *);
     if (!pinfo) {
-        FPGA_MSG("pinfo is NULL");
+        OPAE_MSG("pinfo is NULL");
         goto out_EINVAL;
     }
     if (pinfo->argsz != sizeof(*pinfo)) {
-        FPGA_MSG("wrong structure size");
+        OPAE_MSG("wrong structure size");
         goto out_EINVAL;
     }
     pinfo->flags = 0;
@@ -91,20 +91,20 @@ int umsg_set_mode(mock_object * m, int request, va_list argp){
     UNUSED_PARAM(request);
     struct fpga_port_umsg_cfg *ucfg = va_arg(argp, struct fpga_port_umsg_cfg *);
     if (!ucfg) {
-    	FPGA_MSG("ucfg is NULL");
+    	OPAE_MSG("ucfg is NULL");
     	goto out_EINVAL;
     }
     if (ucfg->argsz != sizeof(*ucfg)) {
-    	FPGA_MSG("wrong structure size");
+    	OPAE_MSG("wrong structure size");
     	goto out_EINVAL;
     }
     if (ucfg->flags != 0) {
-    	FPGA_MSG("unexpected flags %u", ucfg->flags);
+    	OPAE_MSG("unexpected flags %u", ucfg->flags);
     	goto out_EINVAL;
     }
     /* TODO: check hint_bitmap */
     if (ucfg->hint_bitmap >> 8) {
-    	FPGA_MSG("invalid hint_bitmap 0x%x", ucfg->hint_bitmap);
+    	OPAE_MSG("invalid hint_bitmap 0x%x", ucfg->hint_bitmap);
     	goto out_EINVAL;
     }
     retval = 0;

--- a/tests/opae-cxx/test_handle_cxx_core.cpp
+++ b/tests/opae-cxx/test_handle_cxx_core.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018, Intel Corporation
+// Copyright(c) 2018-2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -46,19 +46,19 @@ int mmio_ioctl(mock_object *m, int request, va_list argp) {
   struct fpga_port_region_info *rinfo =
       va_arg(argp, struct fpga_port_region_info *);
   if (!rinfo) {
-    FPGA_MSG("rinfo is NULL");
+    OPAE_MSG("rinfo is NULL");
     goto out_EINVAL;
   }
   if (rinfo->argsz != sizeof(*rinfo)) {
-    FPGA_MSG("wrong structure size");
+    OPAE_MSG("wrong structure size");
     goto out_EINVAL;
   }
   if (rinfo->index > 1) {
-    FPGA_MSG("unsupported MMIO index");
+    OPAE_MSG("unsupported MMIO index");
     goto out_EINVAL;
   }
   if (rinfo->padding != 0) {
-    FPGA_MSG("unsupported padding");
+    OPAE_MSG("unsupported padding");
     goto out_EINVAL;
   }
   rinfo->flags = FPGA_REGION_READ | FPGA_REGION_WRITE | FPGA_REGION_MMAP;

--- a/tests/xfpga/test_afu_metrics_c.cpp
+++ b/tests/xfpga/test_afu_metrics_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2020, Intel Corporation
+// Copyright(c) 2018-2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -59,10 +59,6 @@ extern "C" {
 #include "intel-fpga.h"
 #include "mock/test_system.h"
 
-#undef FPGA_MSG
-#define FPGA_MSG(fmt, ...) \
-	printf("MOCK " fmt "\n", ## __VA_ARGS__)
-
 extern "C" {
 int xfpga_plugin_initialize(void);
 int xfpga_plugin_finalize(void);
@@ -78,19 +74,19 @@ int mmio_ioctl(mock_object *m, int request, va_list argp) {
   struct fpga_port_region_info *rinfo =
       va_arg(argp, struct fpga_port_region_info *);
   if (!rinfo) {
-    FPGA_MSG("rinfo is NULL");
+    OPAE_MSG("rinfo is NULL");
     goto out_EINVAL;
   }
   if (rinfo->argsz != sizeof(*rinfo)) {
-    FPGA_MSG("wrong structure size");
+    OPAE_MSG("wrong structure size");
     goto out_EINVAL;
   }
   if (rinfo->index > 1) {
-    FPGA_MSG("unsupported MMIO index");
+    OPAE_MSG("unsupported MMIO index");
     goto out_EINVAL;
   }
   if (rinfo->padding != 0) {
-    FPGA_MSG("unsupported padding");
+    OPAE_MSG("unsupported padding");
     goto out_EINVAL;
   }
   rinfo->flags = FPGA_REGION_READ | FPGA_REGION_WRITE | FPGA_REGION_MMAP;

--- a/tests/xfpga/test_buffer_c.cpp
+++ b/tests/xfpga/test_buffer_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2017-2020, Intel Corporation
+// Copyright(c) 2017-2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -59,9 +59,6 @@ extern "C" {
 #define MB (1024 * KB)
 #define GB (1024UL * MB)
 #define FPGA_MOCK_IOVA 0xDECAFBADDEADBEEF
-#undef FPGA_MSG
-#define FPGA_MSG(fmt, ...) \
-	printf("MOCK " fmt "\n", ## __VA_ARGS__)
 
 #pragma pack(push, 1)
 struct buffer_params {

--- a/tests/xfpga/test_enum_c.cpp
+++ b/tests/xfpga/test_enum_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2017-2020, Intel Corporation
+// Copyright(c) 2017-2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -65,11 +65,11 @@ int dfl_port_info(mock_object * m, int request, va_list argp){
   UNUSED_PARAM(request);
   struct dfl_fpga_port_info *pinfo = va_arg(argp, struct dfl_fpga_port_info *);
   if (!pinfo) {
-  	FPGA_MSG("pinfo is NULL");
+  	OPAE_MSG("pinfo is NULL");
   	goto out_EINVAL;
   }
   if (pinfo->argsz != sizeof(*pinfo)) {
-  	FPGA_MSG("wrong structure size");
+  	OPAE_MSG("wrong structure size");
   	goto out_EINVAL;
   }
   pinfo->flags = 0;

--- a/tests/xfpga/test_events_c.cpp
+++ b/tests/xfpga/test_events_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2017-2020, Intel Corporation
+// Copyright(c) 2017-2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -61,14 +61,6 @@ int xfpga_plugin_finalize(void);
 #include <linux/ioctl.h>
 #include <poll.h>
 #include <dlfcn.h>
-
-#undef FPGA_MSG
-#define FPGA_MSG(fmt, ...) \
-	printf("MOCK " fmt "\n", ## __VA_ARGS__)
-
-#undef FPGA_ERR
-#define FPGA_ERR(fmt, ...) \
-	printf("MOCK ERROR " fmt "\n", ## __VA_ARGS__)
 
 using namespace opae::testing;
 
@@ -171,11 +163,11 @@ int set_dummy_dfl_irq(mock_object * m, int request, va_list argp) {
 	struct dfl_fpga_irq_set *irq = va_arg(argp, struct dfl_fpga_irq_set *);
 
 	if (!irq) {
-		FPGA_MSG("fme_irq is NULL");
+		OPAE_MSG("fme_irq is NULL");
 		goto out_EINVAL;
 	}
 	if (irq->count <= 0) {
-		FPGA_MSG("wrong structure size");
+		OPAE_MSG("wrong structure size");
 		goto out_EINVAL;
 	}
 
@@ -202,11 +194,11 @@ int set_dfl_irq(mock_object * m, int request, va_list argp) {
 
 	struct dfl_fpga_irq_set *irq = va_arg(argp, struct dfl_fpga_irq_set *);
 	if (!irq) {
-		FPGA_MSG("fme_irq is NULL");
+		OPAE_MSG("fme_irq is NULL");
 		goto out_EINVAL;
 	}
 	if (irq->count <= 0 ) {
-		FPGA_MSG("wrong structure size");
+		OPAE_MSG("wrong structure size");
 		goto out_EINVAL;
 	}
 	if (gEnableIRQ) {
@@ -217,7 +209,7 @@ int set_dfl_irq(mock_object * m, int request, va_list argp) {
 			if (irq->evtfds[i] >= 0)
 				if (write(irq->evtfds[i], &data, sizeof(data)) !=
 					sizeof(data)) {
-					FPGA_ERR("IRQ write < 8 bytes");
+					OPAE_ERR("IRQ write < 8 bytes");
 				}
 		}
 	}

--- a/tests/xfpga/test_metrics_c.cpp
+++ b/tests/xfpga/test_metrics_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2020, Intel Corporation
+// Copyright(c) 2018-2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -59,10 +59,6 @@ extern "C" {
 #include "xfpga.h"
 #include "mock/test_utils.h"
 
-#undef FPGA_MSG
-#define FPGA_MSG(fmt, ...) \
-	printf("MOCK " fmt "\n", ## __VA_ARGS__)
-
 extern "C" {
 int xfpga_plugin_initialize(void);
 int xfpga_plugin_finalize(void);
@@ -78,19 +74,19 @@ int mmio_ioctl(mock_object *m, int request, va_list argp) {
   struct fpga_port_region_info *rinfo =
       va_arg(argp, struct fpga_port_region_info *);
   if (!rinfo) {
-    FPGA_MSG("rinfo is NULL");
+    OPAE_MSG("rinfo is NULL");
     goto out_EINVAL;
   }
   if (rinfo->argsz != sizeof(*rinfo)) {
-    FPGA_MSG("wrong structure size");
+    OPAE_MSG("wrong structure size");
     goto out_EINVAL;
   }
   if (rinfo->index > 1) {
-    FPGA_MSG("unsupported MMIO index");
+    OPAE_MSG("unsupported MMIO index");
     goto out_EINVAL;
   }
   if (rinfo->padding != 0) {
-    FPGA_MSG("unsupported padding");
+    OPAE_MSG("unsupported padding");
     goto out_EINVAL;
   }
   rinfo->flags = FPGA_REGION_READ | FPGA_REGION_WRITE | FPGA_REGION_MMAP;

--- a/tests/xfpga/test_mmio_c.cpp
+++ b/tests/xfpga/test_mmio_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2017-2020, Intel Corporation
+// Copyright(c) 2017-2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -42,10 +42,6 @@
 #include "xfpga.h"
 #include "types_int.h"
 #include "sysfs_int.h"
-
-#undef FPGA_MSG
-#define FPGA_MSG(fmt, ...) \
-	printf("MOCK " fmt "\n", ## __VA_ARGS__)
 
 extern "C" {
 int xfpga_plugin_initialize(void);
@@ -91,19 +87,19 @@ int mmio_ioctl(mock_object * m, int request, va_list argp){
     UNUSED_PARAM(request);
     struct dfl_fpga_port_region_info *rinfo = va_arg(argp, struct dfl_fpga_port_region_info *);
     if (!rinfo) {
-      FPGA_MSG("rinfo is NULL");
+      OPAE_MSG("rinfo is NULL");
       goto out_EINVAL;
     }
     if (rinfo->argsz != sizeof(*rinfo)) {
-      FPGA_MSG("wrong structure size");
+      OPAE_MSG("wrong structure size");
       goto out_EINVAL;
     }
     if (rinfo->index > 1 ) {
-      FPGA_MSG("unsupported MMIO index");
+      OPAE_MSG("unsupported MMIO index");
       goto out_EINVAL;
     }
     if (rinfo->padding != 0) {
-      FPGA_MSG("unsupported padding");
+      OPAE_MSG("unsupported padding");
       goto out_EINVAL;
     }
     rinfo->flags = DFL_PORT_REGION_READ | DFL_PORT_REGION_WRITE | DFL_PORT_REGION_MMAP;

--- a/tests/xfpga/test_mock_errinj_c.cpp
+++ b/tests/xfpga/test_mock_errinj_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2017-2020, Intel Corporation
+// Copyright(c) 2017-2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -40,10 +40,6 @@
 #include "fpga-dfl.h"
 #include "sysfs_int.h"
 
-#undef FPGA_MSG
-#define FPGA_MSG(fmt, ...) \
-	printf("MOCK " fmt "\n", ## __VA_ARGS__)
-
 extern "C" {
 int xfpga_plugin_initialize(void);
 int xfpga_plugin_finalize(void);
@@ -61,7 +57,7 @@ int dfl_port_release_ioctl(mock_object * m, int request, va_list argp){
   int *port_id = va_arg(argp,int*);
 
   if (*port_id != 0) {
-    FPGA_MSG("unexpected port ID %u", *port_id);
+    OPAE_MSG("unexpected port ID %u", *port_id);
     goto out_EINVAL;
   }
   retval = 0;
@@ -87,7 +83,7 @@ int dfl_port_assign_ioctl(mock_object * m, int request, va_list argp){
   int *port_id = va_arg(argp, int*);
 
   if (*port_id != 0) {
-	  FPGA_MSG("unexpected port ID %u", *port_id);
+	  OPAE_MSG("unexpected port ID %u", *port_id);
 	  goto out_EINVAL;
   }
 

--- a/tests/xfpga/test_open_close_c.cpp
+++ b/tests/xfpga/test_open_close_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2017-2020, Intel Corporation
+// Copyright(c) 2017-2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -76,10 +76,6 @@ static bool mmio_map_is_empty(struct wsid_map *root) {
 }
 #endif
 
-#undef FPGA_MSG
-#define FPGA_MSG(fmt, ...) \
-	printf("MOCK " fmt "\n", ## __VA_ARGS__)
-
 int mmio_ioctl(mock_object * m, int request, va_list argp) {
 	int retval = -1;
 	errno = EINVAL;
@@ -87,19 +83,19 @@ int mmio_ioctl(mock_object * m, int request, va_list argp) {
 	UNUSED_PARAM(request);
 	struct dfl_fpga_port_region_info *rinfo = va_arg(argp, struct dfl_fpga_port_region_info *);
 	if (!rinfo) {
-		FPGA_MSG("rinfo is NULL");
+		OPAE_MSG("rinfo is NULL");
 		goto out_EINVAL;
 	}
 	if (rinfo->argsz != sizeof(*rinfo)) {
-		FPGA_MSG("wrong structure size");
+		OPAE_MSG("wrong structure size");
 		goto out_EINVAL;
 	}
 	if (rinfo->index > 1) {
-		FPGA_MSG("unsupported MMIO index");
+		OPAE_MSG("unsupported MMIO index");
 		goto out_EINVAL;
 	}
 	if (rinfo->padding != 0) {
-		FPGA_MSG("unsupported padding");
+		OPAE_MSG("unsupported padding");
 		goto out_EINVAL;
 	}
 	rinfo->flags = DFL_PORT_REGION_READ | DFL_PORT_REGION_WRITE | DFL_PORT_REGION_MMAP;

--- a/tests/xfpga/test_umsg_c.cpp
+++ b/tests/xfpga/test_umsg_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2017-2020, Intel Corporation
+// Copyright(c) 2017-2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -44,10 +44,6 @@ int xfpga_plugin_finalize(void);
 #include "mock/test_system.h"
 #include "sysfs_int.h"
 
-#undef FPGA_MSG
-#define FPGA_MSG(fmt, ...) \
-	printf("MOCK " fmt "\n", ## __VA_ARGS__)
-
 
 using namespace opae::testing;
 
@@ -59,11 +55,11 @@ int umsg_port_info(mock_object * m, int request, va_list argp){
     UNUSED_PARAM(request);
     struct fpga_port_info *pinfo = va_arg(argp, struct fpga_port_info *);
     if (!pinfo) {
-        FPGA_MSG("pinfo is NULL");
+        OPAE_MSG("pinfo is NULL");
         goto out_EINVAL;
     }
     if (pinfo->argsz != sizeof(*pinfo)) {
-        FPGA_MSG("wrong structure size");
+        OPAE_MSG("wrong structure size");
         goto out_EINVAL;
     }
     pinfo->flags = 0;
@@ -94,20 +90,20 @@ int umsg_set_mode(mock_object * m, int request, va_list argp){
     UNUSED_PARAM(request);
     struct fpga_port_umsg_cfg *ucfg = va_arg(argp, struct fpga_port_umsg_cfg *);
     if (!ucfg) {
-    	FPGA_MSG("ucfg is NULL");
+    	OPAE_MSG("ucfg is NULL");
     	goto out_EINVAL;
     }
     if (ucfg->argsz != sizeof(*ucfg)) {
-    	FPGA_MSG("wrong structure size");
+    	OPAE_MSG("wrong structure size");
     	goto out_EINVAL;
     }
     if (ucfg->flags != 0) {
-    	FPGA_MSG("unexpected flags %u", ucfg->flags);
+    	OPAE_MSG("unexpected flags %u", ucfg->flags);
     	goto out_EINVAL;
     }
     /* TODO: check hint_bitmap */
     if (ucfg->hint_bitmap >> 8) {
-    	FPGA_MSG("invalid hint_bitmap 0x%x", ucfg->hint_bitmap);
+    	OPAE_MSG("invalid hint_bitmap 0x%x", ucfg->hint_bitmap);
     	goto out_EINVAL;
     }
     retval = 0;
@@ -128,15 +124,15 @@ int umsg_set_base_addr(mock_object * m, int request, va_list argp){
     UNUSED_PARAM(request);
     struct fpga_port_umsg_base_addr *ubase = va_arg(argp, struct fpga_port_umsg_base_addr *);
     if (!ubase) {
-    	FPGA_MSG("ubase is NULL");
+    	OPAE_MSG("ubase is NULL");
     	goto out_EINVAL;
     }
     if (ubase->argsz != sizeof(*ubase)) {
-    	FPGA_MSG("wrong structure size");
+    	OPAE_MSG("wrong structure size");
     	goto out_EINVAL;
     }
     if (ubase->flags != 0) {
-    	FPGA_MSG("unexpected flags %u", ubase->flags);
+    	OPAE_MSG("unexpected flags %u", ubase->flags);
     	goto out_EINVAL;
     }
     /* TODO: check iova */
@@ -541,9 +537,9 @@ TEST_P(umsg_c_mock_p, get_umsg_ptr_ioctl_err_03_DISABLED) {
  * @test       umsg_c_mock_p
  * @brief      invalid_free_umsg_buffer
  * @details    When the drivers are loaded and handle umsg_virt is mapped,
- *             but ioctl fails on FPGA_PORT_UMSG_DISABLE, FPGA_ERR outputs
+ *             but ioctl fails on FPGA_PORT_UMSG_DISABLE, OPAE_ERR outputs
  *             "Failed to disable UMSG" and returns FPGA_OK
- *             When ioctl fails on FPGA_PORT_UMSG_SET_BASE_ADDR, FPGA_ERR outputs
+ *             When ioctl fails on FPGA_PORT_UMSG_SET_BASE_ADDR, OPAE_ERR outputs
  *             "led to zero UMSG address" and returns FPGA_OK
  *
  */
@@ -570,7 +566,7 @@ TEST_P(umsg_c_mock_p, invalid_free_umsg_buffer_DISABLED) {
  * @test       umsg_c_mock_p
  * @brief      invalid_free_umsg_buffer
  * @details    When the drivers are loaded and handle umsg_virt is mapped,
- *             but ioctl fails on FPGA_PORT_DMA_UNMAP, FPGA_ERR outputs
+ *             but ioctl fails on FPGA_PORT_DMA_UNMAP, OPAE_ERR outputs
  *             "Failed to unmap UMSG Buffer" and returns FPGA_OK
  *
  */


### PR DESCRIPTION
Use OPAE_MSG, OPAE_ERR, and OPAE_DBG instead.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>