### PR TITLE
ofs-umd: fix ofs_add_driver cmake macro

### DIFF
--- a/cmake/modules/OFS.cmake
+++ b/cmake/modules/OFS.cmake
@@ -32,7 +32,7 @@ macro(ofs_add_driver yml_file driver)
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         DEPENDS
             ${CMAKE_CURRENT_LIST_DIR}/${yml_file}
-            ${CMAKE_SOURCE_DIR}/scripts/ofs_parse.py
+            ${OPAE_LIBS_ROOT}/scripts/ofs_parse.py
     )
     add_library(${driver} SHARED
         ${CMAKE_CURRENT_BINARY_DIR}/${driver}.h


### PR DESCRIPTION
Use OPAE_LIBS_ROOT when referencing dependancy ofs_parse.py

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>