### PR TITLE
opae-libs: add python bindings for opaeuio module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,7 @@ opae_add_subdirectory(libofs)
 
 if (OPAE_BUILD_LIBOPAEUIO)
     opae_add_subdirectory(libopaeuio)
+    opae_add_subdirectory(pyopaeuio)
 endif()
 
 if (OPAE_BUILD_LIBOPAEVFIO AND PLATFORM_SUPPORTS_VFIO)

--- a/pyopaeuio/CMakeLists.txt
+++ b/pyopaeuio/CMakeLists.txt
@@ -1,0 +1,32 @@
+## Copyright(c) 2019-2021, Intel Corporation
+##
+## Redistribution  and  use  in source  and  binary  forms,  with  or  without
+## modification, are permitted provided that the following conditions are met:
+##
+## * Redistributions of  source code  must retain the  above copyright notice,
+##   this list of conditions and the following disclaimer.
+## * Redistributions in binary form must reproduce the above copyright notice,
+##   this list of conditions and the following disclaimer in the documentation
+##   and/or other materials provided with the distribution.
+## * Neither the name  of Intel Corporation  nor the names of its contributors
+##   may be used to  endorse or promote  products derived  from this  software
+##   without specific prior written permission.
+##
+## THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+## AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+## IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+## ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+## LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+## CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+## SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+## INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+## CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+## POSSIBILITY OF SUCH DAMAGE.
+
+
+set(INCLUDE_DIRS "${OPAE_INCLUDE_PATH}:${pybind11_ROOT}/include")
+set(LINK_DIRS "${LIBRARY_OUTPUT_PATH}")
+
+pybind11_add_module(pyopaeuio THIN_LTO  pyopaeuio.cpp)
+target_link_libraries(pyopaeuio PRIVATE  opaeuio)

--- a/pyopaeuio/pyopaeuio.cpp
+++ b/pyopaeuio/pyopaeuio.cpp
@@ -1,0 +1,152 @@
+// Copyright(c) 2019-2021, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <exception>
+
+#include "pyopaeuio.h"
+
+// open uio
+int pyopae_uio::open(const std::string& uio_str)
+{
+	int res = 0;
+	num_regions = 0;
+
+	printf("open uio_str.c_str()=%s\n", uio_str.c_str());
+
+	// opae UIO device
+	res = opae_uio_open(&uio, uio_str.c_str());
+	if (res) {
+		throw std::invalid_argument("Failed to open uio ");
+	}
+
+	// get uio region
+	res = opae_uio_region_get(&uio, 0, (uint8_t **)&mmap_ptr, NULL);
+	if (res) {
+		throw std::invalid_argument("Failed to git uio region");
+	}
+
+	struct opae_uio_device_region *r = uio.regions;
+	while (r) {
+		++num_regions;
+		r = r->next;
+	}
+
+	return 0;
+}
+
+// close uio
+int pyopae_uio::close(void)
+{
+	opae_uio_close(&uio);
+	return 0;
+}
+
+// get uio region pointer
+uint8_t *pyopae_uio::get_region(uint32_t region_index, uint32_t offset)
+{
+	if (region_index > num_regions)
+		return NULL;
+
+	struct opae_uio_device_region *r = uio.regions;
+	while (r) {
+		if (r->region_index == region_index)
+			break;
+		r = r->next;
+	}
+
+	if ((r == NULL) || (offset > r->region_size))
+		return NULL;
+
+	return r->region_ptr;
+}
+
+// read 32 bit value
+uint32_t pyopae_uio::read32(uint32_t region_index, uint32_t offset)
+{
+	uint64_t value = 0;
+	uint8_t *ptr = get_region(region_index, offset);
+	if (!ptr) {
+		throw std::invalid_argument("Failed to get uio region");
+	}
+
+	value = *reinterpret_cast<uint32_t *>(ptr + offset);
+	return value;
+}
+
+// read 64 bit value
+uint64_t pyopae_uio::read64(uint32_t region_index, uint32_t offset)
+{
+	uint64_t value = 0;
+	uint8_t *ptr = get_region(region_index, offset);
+	if (!ptr) {
+		throw std::invalid_argument("Failed to get uio region");
+	}
+
+	value = *reinterpret_cast<uint64_t *>(ptr + offset);
+	return value;
+}
+
+// write 32 bit value
+uint32_t pyopae_uio::write32(uint32_t region_index, uint32_t offset, uint32_t value)
+{
+	uint8_t *ptr = get_region(region_index, offset);
+	if (!ptr) {
+		throw std::invalid_argument("Failed to get uio region");
+	}
+
+	*reinterpret_cast<uint32_t *>(ptr+ offset) = value;
+	return 0;
+}
+
+// write 64 bit value
+uint64_t pyopae_uio::write64(uint32_t region_index, uint32_t offset, uint64_t value)
+{
+	uint8_t *ptr = get_region(region_index, offset);
+	if (!ptr) {
+		throw std::invalid_argument("Failed to get uio region");
+	}
+
+	*reinterpret_cast<uint64_t *>(ptr+ offset) = value;
+	return 0;
+}
+
+
+namespace py = pybind11;
+PYBIND11_MODULE(pyopaeuio, m) {
+	m.doc() = "pybind11 pyopaeuio plugin";
+	py::class_<pyopae_uio>(m, "pyopaeuio")
+		.def(py::init<>())
+		.def("open", (int(pyopae_uio::*)(const std::string&))&pyopae_uio::open)
+		.def("close", (int(pyopae_uio::*)(void))&pyopae_uio::close)
+		.def("read32", (uint32_t(pyopae_uio::*)(uint32_t region_index, uint32_t offset))&pyopae_uio::read32)
+		.def("write32", (uint32_t(pyopae_uio::*)(uint32_t region_index, uint32_t offset, uint32_t value))&pyopae_uio::write32)
+		.def("read64", (uint64_t(pyopae_uio::*)(uint32_t region_index, uint32_t offset))&pyopae_uio::read64)
+		.def("write64", (uint64_t(pyopae_uio::*)(uint32_t region_index, uint32_t offset, uint64_t value))&pyopae_uio::write64)
+		.def_readonly("numregions", &pyopae_uio::num_regions);
+}

--- a/pyopaeuio/pyopaeuio.h
+++ b/pyopaeuio/pyopaeuio.h
@@ -1,4 +1,4 @@
-// Copyright(c) 2019-2021, Intel Corporation
+// Copyright(c) 2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -24,7 +24,6 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-
 #ifndef PYOPAE_UIO_H
 #define PYOPAE_UIO_H
 
@@ -36,12 +35,11 @@
 // opae uio python binding class
 class pyopae_uio {
 public:
-	pyopae_uio():num_regions(0), mmap_ptr(NULL)
-		{ }
-	~pyopae_uio() {}
+	pyopae_uio():num_regions(0), uio_mmap_ptr_(nullptr) { }
+	virtual ~pyopae_uio() {}
 
 	int open(const std::string& uio_str);
-	int close();
+	void close();
 	uint32_t read32(uint32_t region_index, uint32_t offset);
 	uint64_t read64(uint32_t region_index, uint32_t offset);
 	uint32_t write32(uint32_t region_index, uint32_t offset, uint32_t value);
@@ -50,8 +48,7 @@ public:
 
 private:
 	uint8_t *get_region(uint32_t region_index, uint32_t offset);
-	uint8_t *mmap_ptr;
-	struct opae_uio uio;
+	uint8_t *uio_mmap_ptr_;
+	struct opae_uio uio_;
 };
-
 #endif //PYOPAE_UIO_H

--- a/pyopaeuio/pyopaeuio.h
+++ b/pyopaeuio/pyopaeuio.h
@@ -1,0 +1,57 @@
+// Copyright(c) 2019-2021, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+
+#ifndef PYOPAE_UIO_H
+#define PYOPAE_UIO_H
+
+#include <string.h>
+#include <iostream>
+#include <stdexcept>
+#include <opae/uio.h>
+
+// opae uio python binding class
+class pyopae_uio {
+public:
+	pyopae_uio():num_regions(0), mmap_ptr(NULL)
+		{ }
+	~pyopae_uio() {}
+
+	int open(const std::string& uio_str);
+	int close();
+	uint32_t read32(uint32_t region_index, uint32_t offset);
+	uint64_t read64(uint32_t region_index, uint32_t offset);
+	uint32_t write32(uint32_t region_index, uint32_t offset, uint32_t value);
+	uint64_t write64(uint32_t region_index, uint32_t offset, uint64_t value);
+	uint32_t num_regions;
+
+private:
+	uint8_t *get_region(uint32_t region_index, uint32_t offset);
+	uint8_t *mmap_ptr;
+	struct opae_uio uio;
+};
+
+#endif //PYOPAE_UIO_H


### PR DESCRIPTION
  -add pybind11 support to opaeuio module
   Python functions
   Open() : opens opae uio  device
   Close()
   Read32() reads 32 bit register
   Read64() reads 64 bit register
   write32() writes 32 bit register
   write 64() writes 64 bit register

Signed-off-by: anandaravuri <ananda.ravuri@intel.com>