### PR TITLE
ofs_parse: simplify schema

### DIFF
--- a/scripts/ofs_parse.py
+++ b/scripts/ofs_parse.py
@@ -29,8 +29,9 @@ import argparse
 import ast
 import io
 import os
-import re
 import yaml
+
+import umd
 
 from collections import OrderedDict
 from contextlib import contextmanager
@@ -40,40 +41,6 @@ try:
 except ImportError:
     from yaml import Loader as YamlLoader
 
-def _ast_get_source_segment(body, node):
-    '''Incomplete reimplementation of ast.get_source_segment()
-
-    This generator script should still work for the target distributions
-    without a shipped Python 3.8+ installation. To be maintainable long term,
-    this script should probably be reworked to avoid source string manipulation
-    and prefer transforming/walking the AST directly to generate target code.
-
-    FIXME -- remove this function
-    '''
-    lines = body.split('\n')
-    first_line = node.lineno-1
-    first_col = node.col_offset
-
-    if hasattr(node, 'end_lineno'):
-        last_line = node.end_lineno-1
-    else:
-        last_line = first_line
-    if hasattr(node, 'end_col_offset'):
-        last_col = node.end_col_offset
-    else:
-        last_col = len(body)
-
-    if first_line == last_line:
-        return lines[first_line][first_col:last_col]
-    else:
-        return '\n'.join([lines[first_line][first_col:],
-                          '\n'.join(lines[first_line+1:last_line]),
-                          lines[last_line][:last_col]])
-
-try:
-    from ast import get_source_segment as ast_get_source_segment
-except ImportError:
-    ast_get_source_segment = _ast_get_source_segment
 
 cpp_field_tmpl = '{spaces}{pod} f_{name} : {width};'
 cpp_class_tmpl = '''
@@ -190,6 +157,24 @@ class ofs_driver_writer(object):
     def __init__(self, data):
         self.data = data
 
+    def resolve_function(self, fn_name):
+        if fn_name in self.fn_names:
+            return f'{self.name}_{fn_name}'
+        return fn_name
+
+    def resolve_name(self, name):
+        if name in self.reg_names:
+            return f'drv->r_{name}'
+        return name
+
+    @property
+    def fn_names(self):
+        return [fn.name for fn in self.functions]
+
+    @property
+    def reg_names(self):
+        return [r.name for r in self.registers]
+
     def api_functions(self, code):
         functions = OrderedDict()
         try:
@@ -230,8 +215,7 @@ class ofs_driver_writer(object):
     def write_header(self, output, language='c'):
         self.name = self.data['name']
         self.registers = self.data['registers']
-        api = self.data.get('api', '')
-        self.functions = self.data.get('functions', self.api_functions(api))
+        self.functions = umd.get_functions(self.data.get('api', ''), self)
         if not self.functions:
             return
         filepath = os.path.join(output, f'{self.name}.h')
@@ -269,96 +253,6 @@ class ofs_driver_writer(object):
             r.fields = declare_fields(r.pod, r.fields, 4)
             r.to_structure(tmpl, fp)
 
-    def find_call(self, node):
-        if isinstance(node, ast.Call):
-            return [node]
-        if isinstance(node, ast.Return) or isinstance(node, ast.Expr):
-            return self.find_call(node.value)
-        if isinstance(node, ast.Compare) or isinstance(node, ast.BinOp):
-            calls = self.find_call(node.left)
-            if isinstance(node, ast.Compare):
-                for c in node.comparators:
-                    calls.extend(self.find_call(c))
-            else:
-                calls.extend(self.find_call(node.right))
-            return calls
-        return []
-
-    def annotation_to_c(self, node):
-        if isinstance(node, ast.Subscript):
-            return node.value.id, node.slice.value.value
-        return node.id, None
-
-    def registers_names(self):
-        return [r.name for r in self.registers]
-
-    def c_convert(self, body, node):
-        def arg_repl(m):
-            fn = m.group(1)
-            args = m.group(2)
-            if m.group(2) and m.group(2).strip():
-                return f'{self.name}_{fn}(drv, {args})'
-            return f'{self.name}_{fn}(drv)'
-
-        line = ast_get_source_segment(body, node)
-
-        for call_node in self.find_call(node):
-            fn_name = call_node.func.id
-            if fn_name in self.functions:
-                line = re.sub(f'({fn_name})\\((.*)\\)', arg_repl, line, flags=re.DOTALL)
-        return self.ofs_resolve(node, self._c_convert(line))
-
-    def ofs_resolve(self, node, line):
-        if node is None:
-            return line
-        if isinstance(node, ast.Call) and node.func.id == 'ofs_addr':
-            func = node.func.id
-            arg0 = node.args[0].id
-            if func == 'ofs_addr' and arg0 in self.registers_names():
-                arg1 = node.args[1].id
-                line = re.sub(f'ofs_addr\\(\\s*({arg0})\\s*,\\s*({arg1})\\s*\\)', # noqa
-                              r'(\2*)drv->r_\1', line)
-                return line
-        if isinstance(node, ast.AnnAssign) or isinstance(node, ast.Assign):
-            # line = self.ofs_resolve(node.target, line)
-            line = self.ofs_resolve(node.value, line)
-            return line
-        if isinstance(node, ast.BinOp):
-            line = self.ofs_resolve(node.left, line)
-            line = self.ofs_resolve(node.right, line)
-            return line
-        if isinstance(node, ast.Name) and node.id in self.registers_names():
-            line = line.replace(node.id, f'drv->r_{node.id}->value')
-        return line
-
-    def find_registers(self, node):
-        if node is None:
-            return []
-        if isinstance(node, ast.BinOp):
-            lhs = self.find_registers(node.left)
-            rhs = self.find_registers(node.right)
-            return lhs + rhs
-        value_id = getattr(node, 'id', None)
-        if value_id and value_id in self.registers_names():
-            return [value_id]
-        return []
-
-    def _c_convert(self, line):
-        p = re.compile(r'(.*?)(?:(?P<r>\w+)\.(?P<f>\w+))(.*)')
-        m = p.match(line)
-        if m:
-            line = m.expand(r'\1drv->r_\2->f_\3\4')
-        f = re.compile(r'(\w+)\((.*?)\)')
-        m = f.match(line)
-        if m and m.group(1) in self.functions:
-            line = f.sub(f'{self.name}_\\1(drv, \\2)', line)
-        for py_syntax, c_syntax in [('not ', '!'),
-                                    (' and ', ' && '),
-                                    ('True', 'true'),
-                                    ('False', 'false')]:
-            line = line.replace(py_syntax, c_syntax)
-        return line
-
     def get_body_text(self, body, lines):
         text = io.StringIO()
         first = body[0]
@@ -369,52 +263,6 @@ class ofs_driver_writer(object):
             else:
                 break
         return text.getvalue()
-
-    def write_scoped_body(self, fp, body, indent=1):
-        spaces = '  '*indent
-        body = re.sub(r'#(.*)', r'__cmt__("\1")', body)
-        parsed = ast.parse(body)
-        lines = body.strip().split('\n')
-        for s in parsed.body:
-            if isinstance(s, ast.Expr) and isinstance(s.value, ast.Call):
-                line = self.c_convert(body, s)
-                if s.value.func.id == '__cmt__':
-                    line = re.sub(r'__cmt__\("(.*?)"\)', r'//\1', line)
-                    fp.writeline(f'{spaces}{line}')
-            elif type(s) in [ast.If, ast.While, ast.For]:
-                if isinstance(s, ast.For) and s.iter.func.id.endswith('range'):
-                    i = s.target.id
-                    _min = 0 if len(s.iter.args) == 1 else s.iter.args[0].id
-                    _max = s.iter.args[-1].id
-                    test = f'{i} = {_min}; i < {_max}; ++i'
-                    keyword = 'for'
-                else:
-                    test = self.c_convert(body, s.test)
-                    keyword = 'if' if isinstance(s, ast.If) else 'while'
-                fp.write(f'{spaces}{keyword} ({test}) {{\n')
-                inner = self.get_body_text(s.body, lines)
-                self.write_scoped_body(fp, inner, indent+1)
-                fp.write(f'{spaces}}}\n')
-            else:
-                line = self.c_convert(body, s)
-                if isinstance(s, ast.AnnAssign):
-                    _type, size = self.annotation_to_c(s.annotation)
-                    _var = s.target.id
-                    if _type.endswith('_ptr'):
-                        _type = _type.replace('_ptr', '')
-                        line = re.sub(
-                            f'({_var}):\\s*({_type})(?:_ptr)([{size}])?',
-                            r'\2 *\1\3', line
-                        )
-                    else:
-                        line = re.sub(
-                            f'({_var}):\\s*({_type})([{size}])?',
-                            r'\2 \1\3', line
-                        )
-                    # if _type.endswith('_ptr'):
-                    #     _type = _type.rstrip('_ptr')
-                    #     _var = f'\\*{_var}'
-                fp.write(f'{spaces}{line};\n')
 
     def write_function(self, fp, function_name, info={}, prototype=False):
         rtype = info.get('return', 'void')
@@ -441,15 +289,17 @@ class ofs_driver_writer(object):
                                        members=members.getvalue().rstrip(),
                                        inits=inits.getvalue().rstrip()))
 
-        impls = []
         fp.write('\n\n// *****  function prototypes ******//\n')
-        for k, v in self.functions.items():
-            if v and 'body' in v:
-                impls.append((k, v))
-            self.write_function(fp, k, v or {}, prototype=True)
+        for fn in self.functions:
+            fp.writeline(f'{fn.write_header()};')
+            fn.visit_tree()
         fp.write('\n\n// *****  function implementations ******//\n')
-        for k, v in impls:
-            self.write_function(fp, k, v or {})
+        for fn in self.functions:
+            if fn.body:
+                fp.writeline(f'{fn.write_header()}')
+                fp.writeline('{')
+                fn.write_body(fp)
+                fp.writeline('}\n')
 
 
 class ofs_header_writer(object):

--- a/scripts/umd.py
+++ b/scripts/umd.py
@@ -1,0 +1,370 @@
+#! /usr/bin/env python3
+# Copyright(c) 2021, Intel Corporation
+#
+# Redistribution  and  use  in source  and  binary  forms,  with  or  without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of  source code  must retain the  above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name  of Intel Corporation  nor the names of its contributors
+#   may be used to  endorse or promote  products derived  from this  software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+# IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+# LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+# CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+# SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+# INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+# CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+# -*- coding: utf-8 -*-
+# vim:fenc=utf-8
+import argparse
+import ast
+import sys
+
+from ofs_parse import parse as ofs_parse
+
+
+class file_writer:
+    pass
+
+
+class fn_visitor(ast.NodeVisitor):
+    def __init__(self, driver):
+        self.driver = driver
+
+    def visit_FunctionDef(self, node):
+        return c_func(self.driver, node)
+
+
+class c_visitor(ast.NodeVisitor):
+    def visit_Add(self, node):
+        return '+'
+
+    def visit_Sub(self, node):
+        return '-'
+
+    def visit_Mult(self, node):
+        return '*'
+
+    def visit_Div(self, node):
+        return '/'
+
+    def visit_Not(self, node):
+        return '!'
+
+    def visit_Lt(self, node):
+        return '<'
+
+    def visit_Gt(self, node):
+        return '>'
+
+    def visit_Eq(self, node):
+        return '=='
+
+
+class decl_visitor(ast.NodeVisitor):
+    def __init__(self, target):
+        self.target = target
+
+    def visit_Name(self, node):
+        return f'{node.id} {self.target}'
+
+    def visit_Call(self, node):
+        if node.func.id == 'ptr':
+            return f'{node.args[0].id} *{self.target}'
+
+    def visit_Subscript(self, node):
+        return f'{node.value.id} {self.target}[{node.slice.value.n}]'
+
+
+class scope_visitor(c_visitor):
+    def __init__(self, driver):
+        self.driver = driver
+
+    def get_decl(self, ann, target):
+        if isinstance(ann, ast.Name):
+            return f'{ann.id} {target}'
+        if isinstance(ann, ast.Call) and ann.func.id == 'ptr':
+            return f'{ann.args[0].id} *{target}'
+        if isinstance(ann, ast.Subscript):
+            return f'{ann.value.id} {target}[{ann.slice.value.n}]'
+
+    def visit_arguments(self, args):
+        return [decl_visitor(a.arg).visit(a.annotation) for a in args.args]
+
+    def visit_If(self, node):
+        new_node = c_if(node, self.driver, self)
+        for s in node.body:
+            new_node.append(self.visit(s))
+        return new_node
+
+    def visit_While(self, node):
+        new_node = c_while(node, self.driver, self)
+        for s in node.body:
+            new_node.append(self.visit(s))
+        return new_node
+
+    def visit_For(self, node):
+        new_node = c_for(node, self.driver, self)
+        for s in node.body:
+            new_node.append(self.visit(s))
+        return new_node
+
+    def visit_Expr(self, node):
+        return self.visit(node.value)
+
+    def visit_Assign(self, node):
+        lhs = self.visit(node.targets[0])
+        rhs = self.visit(node.value)
+        return c_code(f'{lhs} = {rhs}')
+
+    def visit_AugAssign(self, node):
+        lhs = self.visit(node.target)
+        op = self.visit(node.op)
+        rhs = self.visit(node.value)
+        return c_code(f'{lhs} {op}= {rhs}')
+
+    def visit_AnnAssign(self, node):
+        dv = decl_visitor(node.target.id)
+        decl = dv.visit(node.annotation)
+        if node.value:
+            return c_code(f'{decl} = {self.visit(node.value)}')
+        return c_code(decl)
+
+    def visit_Return(self, node):
+        return c_code(f'return {self.visit(node.value)}')
+
+    def visit_Call(self, node):
+        fn = self.driver.resolve_function(node.func.id)
+        args = [self.visit(a) for a in node.args]
+        if fn.startswith(self.driver.name):
+            args.insert(0, 'drv')
+        args = ', '.join(args)
+        return c_code(f'{fn}({args})')
+
+    def visit_BinOp(self, node):
+        lhs = self.visit(node.left)
+        op = self.visit(node.op)
+        rhs = self.visit(node.right)
+        return f'{lhs}{op}{rhs}'
+
+    def visit_UnaryOp(self, node):
+        return f'{self.visit(node.op)}{self.visit(node.operand)}'
+
+    def visit_BoolOp(self, node):
+        raise NotImplementedError("help")
+
+    def visit_Compare(self, node):
+        lhs = self.visit(node.left)
+        op = self.visit(node.ops[0])
+        rhs = self.visit(node.comparators[0])
+        return f'{lhs} {op} {rhs}'
+
+    def visit_Attribute(self, node):
+        if node.value.id in self.driver.reg_names:
+            return f'drv->r_{node.value.id}->f_{node.attr}'
+        return f'{node.value.id}.{node.attr}'
+
+    def visit_Name(self, node):
+        if node.id in self.driver.reg_names:
+            return f'drv->r_{node.id}'
+        return node.id
+
+    def visit_Num(self, node):
+        return str(node.n)
+
+    def visit_Str(self, node):
+        return f'"{node.str}"'
+
+
+class c_node(object):
+    def __init__(self, node):
+        self.node = node
+
+
+class c_code(c_node):
+    def __init__(self, code):
+        self.code = code
+
+    def write_code(self):
+        return self.code
+
+    def __str__(self):
+        return self.code
+
+
+class c_block(c_node):
+    def __init__(self, node, driver, sv: scope_visitor = None):
+        super().__init__(node)
+        self.driver = driver
+        self.body = []
+        self.sv = sv
+
+    def append(self, n):
+        self.body.append(n)
+
+    def write_header(self):
+        raise NotImplementedError(f'{self} must implment write_header')
+
+    def write_body(self, writer: file_writer, indent=1):
+        spaces = '\t'*indent
+        for s in self.body:
+            if isinstance(s, c_block):
+                writer.writeline(f'{spaces}{s.write_header()} {{')
+                s.write_body(writer, indent+1)
+                writer.writeline(f'{spaces}}}')
+            else:
+                writer.writeline(f'{spaces}{s.write_code()};')
+
+
+class c_conditional_block(c_block):
+    def __init__(self, node, driver, sv: scope_visitor = None):
+        super().__init__(node, driver)
+        self.sv = sv
+        self.cond = self.sv.visit(node.test)
+
+    def write_header(self):
+        return f'{self.keyword} ({self.cond})'
+
+
+class c_if(c_conditional_block):
+    keyword = 'if'
+
+
+class c_while(c_conditional_block):
+    keyword = 'while'
+
+
+class c_for(c_block):
+    def write_header(self):
+        target = self.sv.visit(self.node.target)
+        if self.node.iter.func.id in ['range', 'arange']:
+            args = self.node.iter.args
+            if len(args) == 1:
+                start = 0
+                end = args[0].n
+            else:
+                start = args[0].n
+                end = args[1].n
+            if len(args) < 3:
+                step = f'{target}++' if end > start else f'{target}--'
+            else:
+                step = args[2].n
+                if step > 0:
+                    step = f'+={step}'
+                else:
+                    step = f'-={step}'
+                step = f'{target}{step}'
+            for_range = f'{target} = {start}; i < {end}; {step}'
+        elif self.node.iter.func.id == 'c':
+            for_range = self.node.iter.args[0].s
+        return f'for ({for_range})'
+
+
+class c_func(c_block):
+    def __init__(self, driver, node):
+        super().__init__(node, driver)
+        self.driver = driver
+        self.name = node.name
+        self.returns = node.returns.id if node.returns else 'void'
+        self.sv = scope_visitor(driver)
+
+    def write_header(self):
+        params = [f'{self.driver.name} *drv'] + self.sv.visit(self.node.args)
+        params = ', '.join(params)
+        return f'{self.returns} {self.driver.name}_{self.name}({params})'
+
+    def visit_tree(self):
+        for s in self.node.body:
+            if isinstance(s, ast.Pass):
+                break
+            self.body.append(self.sv.visit(s))
+
+
+class driver_writer(file_writer):
+    def __init__(self, name, fp, registers=[], functions=[]):
+        self.name = name
+        self.fp = fp
+        self.set_context(registers, functions)
+
+    def set_context(self, registers, functions):
+        self.registers = registers
+        self.functions = functions
+        self.reg_names = [r.name for r in registers]
+        self.fn_names = [f.name for f in functions]
+
+    def resolve_function(self, fn_name):
+        if fn_name in self.fn_names:
+            return f'{self.name}_{fn_name}'
+        return fn_name
+
+    def resolve_name(self, name):
+        if name in self.reg_names:
+            return f'drv->r_{name}'
+        return name
+
+    def writefile(self):
+        for fn in self.functions:
+            self.writeline(f'{fn.write_header()};')
+
+        for fn in self.functions:
+            fn.visit_tree()
+            self.writeline(f'{fn.write_header()}')
+            self.writeline('{')
+            fn.write_body(self)
+            self.writeline('}')
+
+    def writeline(self, text):
+        self.fp.write(f'{text}\n')
+
+
+def get_functions(code, driver):
+    functions = []
+    try:
+        tree = ast.parse(code)
+    except SyntaxError as err:
+        raise SystemExit(f'syntax err: {err.text}')
+    else:
+        fv = fn_visitor(driver)
+        for node in tree.body:
+            functions.append(fv.visit(node))
+    return functions
+
+
+def writefile(args):
+    data = ofs_parse(args.file)
+    name = data['name']
+    registers = data['registers']
+    try:
+        tree = ast.parse(data.get('api', ''))
+    except SyntaxError as err:
+        raise SystemExit(f'syntax err: {err.text}')
+
+    wr = driver_writer(name, args.output)
+    functions = []
+    for f in tree.body:
+        functions.append(fn_visitor(wr).visit(f))
+    wr.set_context(registers, functions)
+    wr.writefile()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('file', type=argparse.FileType('r'))
+    parser.add_argument('output', type=argparse.FileType('w'),
+                        nargs='?', default=sys.stdout)
+    args = parser.parse_args()
+    writefile(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/ofs_driver/ofs_test.yml
+++ b/tests/ofs_driver/ofs_test.yml
@@ -21,7 +21,7 @@ registers:
 api: |
   def read_guid(guid: uint8_t[16]):
       sz: size_t = 16
-      ptr: uint8_t_ptr = ofs_addr(id_lo, uint8_t) + sz
+      ptr: uint8_t_ptr = ref(id_lo, uint8_t_ptr) + sz
       i: size_t
       for i in range(sz):
         guid[i] = *--ptr

--- a/tests/ofs_driver/ofs_test.yml
+++ b/tests/ofs_driver/ofs_test.yml
@@ -1,30 +1,27 @@
 %TAG !! tag:intel.com,2020:
 ---
-drivers:
-  - name: ofs_test
-    functions:
-      read_guid:
-        args: ["uint8_t guid[16]"]
-        body: |
-          sz: size_t = 16
-          ptr: uint8_t_ptr = ofs_addr(id_lo, uint8_t) + sz
-          i: size_t
-          for i in range(sz):
-            guid[i] = *--ptr
-    registers:
-    - !!ofs/register
-      - [fme_dfh,      0x0000, 0x5010010000000000, "FME DFH"]
-      - - [feature_type,      [63, 60], ro, 0x5, "Feature Type"]
-        - [dfh_version,       [59, 52], ro, 0x1, "DFH Version"]
-        - [feature_minor_rev, [51, 48], ro, 0x0, "Feature Minor Revision"]
-        - [reserved41,        [47, 41], ro, 0x0, "Reserved"]
-        - [eol,               [40]    , ro, 0x0, "End of List"]
-        - [next_offset,       [39, 16], ro, 0x1000, "Next DFH Offset"]
-        - [feature_major_ver, [15, 12], ro, 0x0, "User defined"]
-        - [feature_id,        [11,  0], ro, 0x0, "Feature ID"]
-    - !!ofs/register
-      - [id_lo,        0x0008, 0xB449F9F67228EBF4, "GUID Lower 64 bits"]
-      - - [bits, [63,0], RO, 0xB449F9F67228EBF4, "Lower 64 bits"]
-    - !!ofs/register
-      - [id_hi,        0x0010, 0xB449F9F67228EBF4, "GUID Upper 64 bits"]
-      - - [bits, [63,0], RO, 0xB449F9F67228EBF4, "Lower 64 bits"]
+name: ofs_test
+registers:
+- !!ofs/register
+  - [fme_dfh,      0x0000, 0x5010010000000000, "FME DFH"]
+  - - [feature_type,      [63, 60], ro, 0x5, "Feature Type"]
+    - [dfh_version,       [59, 52], ro, 0x1, "DFH Version"]
+    - [feature_minor_rev, [51, 48], ro, 0x0, "Feature Minor Revision"]
+    - [reserved41,        [47, 41], ro, 0x0, "Reserved"]
+    - [eol,               [40]    , ro, 0x0, "End of List"]
+    - [next_offset,       [39, 16], ro, 0x1000, "Next DFH Offset"]
+    - [feature_major_ver, [15, 12], ro, 0x0, "User defined"]
+    - [feature_id,        [11,  0], ro, 0x0, "Feature ID"]
+- !!ofs/register
+  - [id_lo,        0x0008, 0xB449F9F67228EBF4, "GUID Lower 64 bits"]
+  - - [bits, [63,0], RO, 0xB449F9F67228EBF4, "Lower 64 bits"]
+- !!ofs/register
+  - [id_hi,        0x0010, 0xB449F9F67228EBF4, "GUID Upper 64 bits"]
+  - - [bits, [63,0], RO, 0xB449F9F67228EBF4, "Lower 64 bits"]
+api: |
+  def read_guid(guid: uint8_t[16]):
+      sz: size_t = 16
+      ptr: uint8_t_ptr = ofs_addr(id_lo, uint8_t) + sz
+      i: size_t
+      for i in range(sz):
+        guid[i] = *--ptr


### PR DESCRIPTION
Simplify schema of input yaml file by:
* Assuming one driver implementation at top level
  (instead of having a list of drivers).
* Allow 'api' keyword with Python text as the value.
  * This text gets parsed using ast.parse and the same function
    information (function name, args, return type...) is extracted to
    later be fed into 'write_header
  * Add 'api_functions' function to do processing mentioned above
* Refactor routine to extract the body of a nested block
  (functions, if, while, etc.) into a function called 'get_body_text'
* Change schema in test yaml file

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>