### PR TITLE
add .gitattributes to this repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+text=auto
+
+*.c text
+*.h text
+*.cpp text
+*.hpp text
+*.yml text
+*.yaml text
+*.json text
+*.py text
+
+version.py export-subst
+version.py filter=gethash


### PR DESCRIPTION
This configuration of gitattributes should auto-convert line endings.
From the docs in github, setting text to 'auto':
"Git will handle files in whatever way it thinks is best"

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>