### PR TITLE
opae-libs: reword blacklist to error exclude list

### DIFF
--- a/plugins/xfpga/error.c
+++ b/plugins/xfpga/error.c
@@ -261,7 +261,7 @@ build_error_list(const char *path, struct error_list **list)
 		if (de->d_name[0] == '.')
 			continue;
 
-		// skip names on blacklist
+		// skip names on the excluded errors list
 		for (i = 0; i < NUM_ERRORS_EXCLUDE; i++) {
 			if (strcmp(de->d_name, errors_exclude[i]) == 0) {
 				break;
@@ -299,7 +299,7 @@ build_error_list(const char *path, struct error_list **list)
 			continue;
 		}
 
-		// not blacklisted, not hidden, accessible, no symlink, no dir -> count and append it!
+		// not an excluded error, not hidden, accessible, no symlink, no dir -> count and append it!
 		n++;
 		if (!el)	// no list
 			continue;


### PR DESCRIPTION
blacklist is problematic language.
In this case it refers to the not reporting errors that match the
entries in the error_exclude[].  So refer to the specific list
instead of the general term.

Signed-off-by: Tom Rix <trix@redhat.com>