### PR TITLE
ofs: fix umd.py code gen script

### DIFF
--- a/cmake/modules/OFS.cmake
+++ b/cmake/modules/OFS.cmake
@@ -33,6 +33,7 @@ macro(ofs_add_driver yml_file driver)
         DEPENDS
             ${CMAKE_CURRENT_LIST_DIR}/${yml_file}
             ${OPAE_LIBS_ROOT}/scripts/ofs_parse.py
+            ${OPAE_LIBS_ROOT}/scripts/umd.py
     )
     add_library(${driver} SHARED
         ${CMAKE_CURRENT_BINARY_DIR}/${driver}.h

--- a/scripts/umd.py
+++ b/scripts/umd.py
@@ -88,6 +88,23 @@ class c_visitor(ast.NodeVisitor):
     def visit_Eq(self, node):
         return '=='
 
+    def visit_Num(self, node):
+        return str(node.n)
+
+    def visit_Str(self, node):
+        return f'"{node.s}"'
+
+    def visit_Index(self, node):
+        return self.visit(node.value)
+
+    def visit_Constant(self, node):
+        if isinstance(node.value, str):
+            return f'"{node.value}"'
+        return str(node.value)
+
+    def visit_Name(self, node):
+        return node.id
+
 
 class decl_visitor(c_visitor):
     def __init__(self, target):
@@ -102,7 +119,7 @@ class decl_visitor(c_visitor):
             return f'{node.args[0].id} *{self.target}'
 
     def visit_Subscript(self, node):
-        return f'{node.value.id} {self.target}[{node.slice.value.n}]'
+        return f'{node.value.id} {self.target}[{self.visit(node.slice)}]'
 
 
 class scope_visitor(c_visitor):
@@ -199,12 +216,6 @@ class scope_visitor(c_visitor):
             return f'drv->r_{node.id}->value'
         return node.id
 
-    def visit_Num(self, node):
-        return str(node.n)
-
-    def visit_Str(self, node):
-        return f'"{node.s}"'
-
     def visit_Starred(self, node):
         return f'*{self.visit(node.value)}'
 
@@ -212,7 +223,7 @@ class scope_visitor(c_visitor):
         return '-'
 
     def visit_Subscript(self, node):
-        return f'{node.value.id}[{self.visit(node.slice.value)}]'
+        return f'{node.value.id}[{self.visit(node.slice)}]'
 
 
 class c_node(object):


### PR DESCRIPTION
Python 3.9 ast NodeVisitor has a visit_Constant interface whereas older
versions used visit_Num and visit_Str.
This change:
* refactors/updates c_visitor class to implement
  * visit_Constant
  * visit_Str
  * visit_Num
  * visit_Index
  * visit_Name
* changes visit_Subscript to visit node.slice
* adds umd.py to dependencies in 'ofs_add_driver' cmake macro

With the new visitor methods in c_visitor, the index value in a '[]'
operator will resolve to the correct value in Python 3.9 as well as
older versions.

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>