### PR TITLE
cmake: add OPAE_GTEST_OUTPUT cmake variable

### DIFF
--- a/cmake/modules/OPAETest.cmake
+++ b/cmake/modules/OPAETest.cmake
@@ -100,9 +100,14 @@ function(opae_test_add)
     opae_coverage_build(TARGET ${OPAE_TEST_ADD_TARGET}
         SOURCE ${OPAE_TEST_ADD_SOURCE})
 
+    if (OPAE_GTEST_OUTPUT)
+        set(test_args
+            "--gtest_output=xml:${OPAE_GTEST_OUTPUT}/${OPAE_TEST_ADD_TARGET}.xml")
+    endif (OPAE_GTEST_OUTPUT)
+
     add_test(
         NAME ${OPAE_TEST_ADD_TARGET}
-        COMMAND $<TARGET_FILE:${OPAE_TEST_ADD_TARGET}>
+        COMMAND $<TARGET_FILE:${OPAE_TEST_ADD_TARGET}> ${test_args}
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     )
 endfunction()


### PR DESCRIPTION
Change opae_test_add function to check for this variable.
If set, it will treat is an indication to run the gtests
with xml output.

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>