### PR TITLE
vfio-plugin: fix get_guid to use 64bit rd

### DIFF
--- a/plugins/vfio/opae_vfio.c
+++ b/plugins/vfio/opae_vfio.c
@@ -28,6 +28,7 @@
 #endif // HAVE_CONFIG_H
 
 #define _GNU_SOURCE
+#include <byteswap.h>
 #include <linux/limits.h>
 #include <errno.h>
 #include <glob.h>
@@ -618,12 +619,10 @@ fpga_result vfio_fpgaReset(fpga_handle handle)
 fpga_result get_guid(uint64_t *h, fpga_guid guid)
 {
 	ASSERT_NOT_NULL(h);
-	size_t sz = 16;
-	uint8_t *ptr = ((uint8_t *)h)+sz;
 
-	for (size_t i = 0; i < sz; ++i) {
-		guid[i] = *--ptr;
-	}
+	uint64_t *ptr = (uint64_t*)guid;
+	*ptr = bswap_64(*(h+1));
+	*(ptr+1) = bswap_64(*h);
 	return FPGA_OK;
 }
 


### PR DESCRIPTION
Current implementation of get_guid copies the input bytes (uint64_t *h)
in reverse order but because it does so per byte, the result is 32-bit
MMIO accesses. This change dereferences the two 64-bit words and calls
bswap_64 to have the bytes swapped and assigns the result to the output
guid variable.

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>