### PR TITLE
opae-c: associate af00 with opae-v

### DIFF
--- a/libopae-c/pluginmgr.c
+++ b/libopae-c/pluginmgr.c
@@ -70,6 +70,7 @@ static platform_data platform_data_table[] = {
 	{ 0x8086, 0x0b30, "libxfpga.so", 0 },
 	{ 0x8086, 0x0b31, "libxfpga.so", 0 },
 	{ 0x8086, 0xaf00, "libxfpga.so", 0 },
+	{ 0x8086, 0xaf00, "libopae-v.so", 0 },
 	{ 0x8086, 0xaf01, "libopae-v.so", 0 },
 	{      0,      0,          NULL, 0 },
 };


### PR DESCRIPTION
Add another line to the the plugin manager vendor/device id that
associates opae-v with 8086:af00. Doing this will cause the plugin
manager to load both plugins (xfpga and opae-v) whenever it detects a
platform of 8086:af00.

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>