### PR TITLE
vfio: fix order of freeing buffers

### DIFF
--- a/libopaevfio/opaevfio.c
+++ b/libopaevfio/opaevfio.c
@@ -391,12 +391,14 @@ opae_vfio_destroy_buffer(struct opae_vfio *, struct opae_vfio_buffer *);
 
 STATIC void opae_vfio_destroy(struct opae_vfio *v)
 {
+	// destroy buffers before we close any FDs
+	opae_vfio_destroy_buffer(v, v->cont_buffers);
+	v->cont_buffers = NULL;
+
 	opae_vfio_device_destroy(&v->device);
 	opae_vfio_group_destroy(&v->group);
 	opae_vfio_destroy_iova_range(v->cont_ranges);
 	v->cont_ranges = NULL;
-	opae_vfio_destroy_buffer(v, v->cont_buffers);
-	v->cont_buffers = NULL;
 
 	mem_alloc_destroy(&v->iova_alloc);
 

--- a/plugins/vfio/opae_vfio.c
+++ b/plugins/vfio/opae_vfio.c
@@ -210,9 +210,6 @@ void free_buffer_list(void)
 	while (ptr) {
 		tmp = ptr;
 		ptr = tmp->next;
-		if (opae_vfio_buffer_free(tmp->vfio_device, tmp->virtual)) {
-			OPAE_ERR("error freeing vfio buffer");
-		}
 		free(tmp);
 	}
 }


### PR DESCRIPTION
* Remove call to opae_vfio_buffer_free in free_buffer_list as this is
taken care of by libopaevfio.
* Move call to destroy buffers before destroying vfio related structures
that have file descriptors that will be closed.

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>