### PR TITLE
build: add 'lcov' target in cmake

### DIFF
--- a/cmake/modules/OPAECompiler.cmake
+++ b/cmake/modules/OPAECompiler.cmake
@@ -358,3 +358,32 @@ function(opae_add_static_library)
                 COMPONENT ${OPAE_ADD_STATIC_LIBRARY_COMPONENT})
     endif(OPAE_ADD_STATIC_LIBRARY_COMPONENT)
 endfunction()
+
+if(CMAKE_BUILD_TYPE STREQUAL "Coverage")
+    set(EXCLUDE_COVERAGE
+        '/usr/**'
+        '*/libopaecxx/samples/**'
+        '*/pyopae/**'
+        '*/plugins/xfpga/usrclk/**'
+        '*/tests/**'
+        '*/tools/extra/c++utils/**'
+        '*/tools/extra/mmlink/**'
+        '*/tools/extra/fpgabist/**'
+        '*/tools/extra/fpgadiag/**'
+        '*/pybind11/**'
+        '*/external/opae-test/**'
+        '*/external/gtest/**'
+        '*/external/CLI11/**'
+        '*/external/spdlog/**'
+    )
+    add_custom_target(lcov
+        COMMAND lcov --directory .  --zerocounters
+        COMMAND lcov -c -i -d . -o coverage.base
+        COMMAND ${CMAKE_MAKE_PROGRAM} test
+        COMMAND lcov --directory . --capture -o coverage.info
+        COMMAND lcov -a coverage.base -a coverage.info -o coverage.total
+        COMMAND lcov --remove coverage.total ${EXCLUDE_COVERAGE} -o coverage.cleaned
+        COMMAND genhtml --function-coverage -o coverage_report coverage.cleaned
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    )
+endif(CMAKE_BUILD_TYPE STREQUAL "Coverage")


### PR DESCRIPTION
'make lcov' runs commands to zero counters, run tests, then catpure end
counters and remove coverage from an exclude list before generating html
coverage report.

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>