### PR TITLE
add support for PCI device id bcce

### DIFF
--- a/libopae-c/pluginmgr.c
+++ b/libopae-c/pluginmgr.c
@@ -69,6 +69,8 @@ static platform_data platform_data_table[] = {
 	{ 0x8086, 0x0b2c, "libxfpga.so", 0 },
 	{ 0x8086, 0x0b30, "libxfpga.so", 0 },
 	{ 0x8086, 0x0b31, "libxfpga.so", 0 },
+	{ 0x8086, 0xbcce, "libxfpga.so", 0 },
+	{ 0x8086, 0xbcce, "libopae-v.so", 0 },
 	{ 0x8086, 0xaf00, "libxfpga.so", 0 },
 	{ 0x8086, 0xaf00, "libopae-v.so", 0 },
 	{ 0x8086, 0xaf01, "libopae-v.so", 0 },

--- a/plugins/vfio/opae_vfio.c
+++ b/plugins/vfio/opae_vfio.c
@@ -276,8 +276,8 @@ int pci_discover(void)
 	int gres = glob(gpattern, 0, NULL, &pg);
 
 	if (gres) {
-		ERR("error looking in vfio-pci");
-		return res;
+		OPAE_MSG("vfio-pci not bound to any PCIe enpoint");
+		return 0;
 	}
 	if (!pg.gl_pathc) {
 		goto free;

--- a/plugins/xfpga/metrics/metrics_max10.c
+++ b/plugins/xfpga/metrics/metrics_max10.c
@@ -163,6 +163,7 @@ fpga_result  dfl_enum_max10_metrics_info(struct _fpga_handle *_handle,
 	char group_sysfs[SYSFS_PATH_MAX]           = { 0, };
 	char qualifier_name[SYSFS_PATH_MAX]        = { 0, };
 	char metric_units[SYSFS_PATH_MAX]          = { 0, };
+	char glob_path[SYSFS_PATH_MAX]             = { 0, };
 	glob_t pglob;
 	size_t len;
 
@@ -180,11 +181,18 @@ fpga_result  dfl_enum_max10_metrics_info(struct _fpga_handle *_handle,
 	}
 
 	// metrics group
-	if (snprintf(sysfspath, sizeof(sysfspath),
+	if (snprintf(glob_path, sizeof(glob_path),
 		"%s/%s", _token->sysfspath, DFL_MAX10_SYSFS_PATH) < 0) {
 		OPAE_ERR("snprintf failed");
 		return FPGA_EXCEPTION;
 	}
+
+	result = find_glob_path(glob_path, sysfspath);
+	if (result != FPGA_OK) {
+		OPAE_MSG("Failed to find sysfs path");
+		return result;
+	}
+
 
 	int gres = glob(sysfspath, GLOB_NOSORT, NULL, &pglob);
 	if ((gres) || (1 != pglob.gl_pathc)) {
@@ -199,11 +207,12 @@ fpga_result  dfl_enum_max10_metrics_info(struct _fpga_handle *_handle,
 	globfree(&pglob);
 
 	// Enum sensors
-	if (snprintf(sysfspath, sizeof(sysfspath),
-		"%s/%s", _token->sysfspath, DFL_MAX10_SENSOR_SYSFS_PATH) < 0) {
-		OPAE_ERR("snprintf failed");
-		return FPGA_EXCEPTION;
+	if (strlen(sysfspath) + sizeof(DFL_MAX10_SYSFS_LABEL) >= SYSFS_PATH_MAX) {
+		OPAE_ERR("Invalid sensor sysfs path length");
+		result = FPGA_EXCEPTION;
+		goto out;
 	}
+	strncat(sysfspath, DFL_MAX10_SYSFS_LABEL, strlen(DFL_MAX10_SYSFS_LABEL) + 1);
 
 	gres = glob(sysfspath, GLOB_NOSORT, NULL, &pglob);
 	if (gres) {

--- a/plugins/xfpga/metrics/metrics_max10.h
+++ b/plugins/xfpga/metrics/metrics_max10.h
@@ -33,8 +33,8 @@
 #define __FPGA_METRICS_MAX10_H__
 
 
-#define DFL_MAX10_SYSFS_PATH                     "dfl*/*spi*/spi_master/spi*/spi*/*/hwmon/hwmon*"
-#define DFL_MAX10_SENSOR_SYSFS_PATH              "dfl*/*spi*/spi_master/spi*/spi*/*/hwmon/hwmon*/*_label"
+#define DFL_MAX10_SYSFS_PATH                     "dfl*/*spi_master/spi*/spi*/*/hwmon/hwmon*"
+#define DFL_MAX10_SENSOR_SYSFS_PATH              DFL_MAX10_SYSFS_PATH"/*_label"
 #define DFL_TEMPERATURE                         "temp"
 #define DFL_VOLTAGE                             "in"
 #define DFL_CURRENT                             "curr"

--- a/plugins/xfpga/metrics/metrics_max10.h
+++ b/plugins/xfpga/metrics/metrics_max10.h
@@ -33,8 +33,8 @@
 #define __FPGA_METRICS_MAX10_H__
 
 
-#define DFL_MAX10_SYSFS_PATH                     "dfl*/*spi_master/spi*/spi*/*/hwmon/hwmon*"
-#define DFL_MAX10_SENSOR_SYSFS_PATH              DFL_MAX10_SYSFS_PATH"/*_label"
+#define DFL_MAX10_SYSFS_PATH                     "*dfl*/*spi*/*spi*/**/hwmon/hwmon*/"
+#define DFL_MAX10_SYSFS_LABEL                    "*_label"
 #define DFL_TEMPERATURE                         "temp"
 #define DFL_VOLTAGE                             "in"
 #define DFL_CURRENT                             "curr"

--- a/plugins/xfpga/sysfs.c
+++ b/plugins/xfpga/sysfs.c
@@ -2479,6 +2479,8 @@ fpga_result find_glob_path(const char *sysfspath, char *path)
 		while (found) {
 			free(object_paths[--found]);
 		}
+	} else {
+		return FPGA_NOT_FOUND;
 	}
 
 	return res;

--- a/plugins/xfpga/sysfs.c
+++ b/plugins/xfpga/sysfs.c
@@ -93,7 +93,7 @@ static sysfs_formats sysfs_path_table[OPAE_KERNEL_DRIVERS] = {
 	 .sysfs_port_err = "errors/errors",
 	 .sysfs_port_err_clear = "errors/errors",
 	 .sysfs_bmc_glob = "avmmi-bmc.*/bmc_info",
-	 .sysfs_max10_glob = "dfl*/*spi*/spi_master/spi*/spi*.*"
+	 .sysfs_max10_glob = "dfl*/*spi_master/spi*/spi*.*"
 	},
 	// intel driver sysfs formats
 	{.sysfs_class_path = "/sys/class/fpga",

--- a/plugins/xfpga/sysfs.c
+++ b/plugins/xfpga/sysfs.c
@@ -2325,7 +2325,7 @@ fpga_result make_sysfs_object(char *sysfspath, const char *name,
 			res = find_glob_path(sysfspath, full_path);
 			if (res != FPGA_OK) {
 				OPAE_ERR("Invalid recursive input path");
-				return FPGA_INVALID_PARAM;
+				return res;
 			}
 			len = strnlen(full_path, SYSFS_PATH_MAX - 1);
 			memcpy(sysfspath, full_path, len);

--- a/plugins/xfpga/sysfs.c
+++ b/plugins/xfpga/sysfs.c
@@ -2316,65 +2316,21 @@ fpga_result make_sysfs_object(char *sysfspath, const char *name,
 	char *object_paths[MAX_SYSOBJECT_GLOB] = { NULL };
 	size_t found = 0;
 	size_t len;
-	int resurse_depth = MAX_SYSOBJECT_GLOB_RESURSIVE_DEPTH;
-	char pattern[SYSFS_PATH_MAX] = { 0 };
 	char full_path[SYSFS_PATH_MAX] = { 0 };
-	char prefix_path[SYSFS_PATH_MAX] = { 0 };
 
 	if (flags & FPGA_OBJECT_GLOB) {
 
 		// Check "**"recursive pattern in sysfs path
 		if (strstr(sysfspath, "/**/")) {
-			char *p = strstr(sysfspath, "/**/");
-			if (p == NULL)
+			res = find_glob_path(sysfspath, full_path);
+			if (res != FPGA_OK) {
+				OPAE_ERR("Invalid recursive input path");
 				return FPGA_INVALID_PARAM;
-
-			// search for multipule pattern "/**/"
-			char *ptr = p;
-			while (ptr != NULL) {
-				ptr++;
-				found++;
-				if (found > 1) {
-					return FPGA_INVALID_PARAM;
-				}
-				ptr = strstr(ptr, "/**/");
 			}
-			found = 0;
-
-			// Prefix substring
-			memcpy(prefix_path, sysfspath, p - sysfspath);
-			*(prefix_path + (p - sysfspath)) = '\0';
-
-			// while loop depth 5
-			while (resurse_depth) {
-				memset(full_path, 0, sizeof(full_path));
-				len = strnlen(pattern, SYSFS_PATH_MAX - 1);
-				strncat(pattern, "*/", SYSFS_PATH_MAX - len);
-
-				if (snprintf(full_path, SYSFS_PATH_MAX,
-					"%s%s%s", prefix_path, pattern, p + 4) < 0) {
-					OPAE_ERR("snprintf buffer overflow");
-					return FPGA_EXCEPTION;
-				}
-
-				res = opae_glob_paths(full_path, MAX_SYSOBJECT_GLOB,
-					object_paths, &found);
-
-				resurse_depth--;
-
-				if (res) {
-					continue;
-				}
-
-				if (found > 0) {
-					len = strnlen(object_paths[0], SYSFS_PATH_MAX - 1);
-					memcpy(sysfspath, object_paths[0], len);
-					sysfspath[len] = '\0';
-					break;
-				}
-
-			} // end
-		}
+			len = strnlen(full_path, SYSFS_PATH_MAX - 1);
+			memcpy(sysfspath, full_path, len);
+			sysfspath[len] = '\0';
+		}// end
 
 		res = opae_glob_paths(sysfspath, MAX_SYSOBJECT_GLOB,
 				      object_paths, &found);
@@ -2518,11 +2474,11 @@ fpga_result find_glob_path(const char *sysfspath, char *path)
 				break;
 			}
 
-			while (found) {
-				free(object_paths[--found]);
-			}
-
 		} // end
+
+		while (found) {
+			free(object_paths[--found]);
+		}
 	}
 
 	return res;

--- a/plugins/xfpga/sysfs.c
+++ b/plugins/xfpga/sysfs.c
@@ -1695,6 +1695,7 @@ enum fpga_hw_type opae_id_to_hw_type(uint16_t vendor_id, uint16_t device_id)
 		case 0x0b2b: /* FALLTHROUGH */
 		case 0x0b2c:
 		case 0xaf00:
+		case 0xbcce:
 			hw_type = FPGA_HW_DCP_D5005;
 		break;
 

--- a/plugins/xfpga/sysfs_int.h
+++ b/plugins/xfpga/sysfs_int.h
@@ -146,6 +146,7 @@ fpga_result sysfs_get_fme_perf_path(fpga_token token, char *sysfs_perf);
 fpga_result sysfs_get_bmc_path(fpga_token token, char *sysfs_bmc);
 fpga_result sysfs_get_max10_path(fpga_token token, char *sysfs_max10);
 fpga_result check_sysfs_path_is_valid(const char *sysfs_path);
+fpga_result find_glob_path(const char *sysfspath, char *path);
 #ifdef __cplusplus
 }
 #endif

--- a/tests/xfpga/test_metrics_max10_c.cpp
+++ b/tests/xfpga/test_metrics_max10_c.cpp
@@ -114,8 +114,8 @@ TEST_P(metrics_max10_c_p, test_metric_max10_1) {
   void *buf = NULL;
   char file[] = "curr1_input";
   char sysfs[] =
-		"/sys/class/fpga_region/region*/dfl-fme.*/dfl-fme.*/"
-		"*spi_master/spi*/spi*/*-hwmon.*.auto/hwmon/hwmon*";
+		"/sys/class/fpga_region/region*/dfl-fme.*/dfl-fme.*/*spi*/"
+		"spi_master/spi*/spi*/*-hwmon.*.auto/hwmon/hwmon*";
 
   EXPECT_NE(read_sensor_sysfs_file(NULL, file, &buf, &tot_bytes_ret), FPGA_OK);
   if (buf) {

--- a/tests/xfpga/test_metrics_max10_c.cpp
+++ b/tests/xfpga/test_metrics_max10_c.cpp
@@ -114,8 +114,8 @@ TEST_P(metrics_max10_c_p, test_metric_max10_1) {
   void *buf = NULL;
   char file[] = "curr1_input";
   char sysfs[] =
-		"/sys/class/fpga_region/region*/dfl-fme.*/dfl-fme.*/*spi*/"
-		"spi_master/spi*/spi*/*-hwmon.*.auto/hwmon/hwmon*";
+		"/sys/class/fpga_region/region*/dfl-fme.*/dfl-fme.*/"
+		"*spi_master/spi*/spi*/*-hwmon.*.auto/hwmon/hwmon*";
 
   EXPECT_NE(read_sensor_sysfs_file(NULL, file, &buf, &tot_bytes_ret), FPGA_OK);
   if (buf) {

--- a/tests/xfpga/test_sysfs_c.cpp
+++ b/tests/xfpga/test_sysfs_c.cpp
@@ -807,7 +807,7 @@ TEST_P(sysfs_c_mock_p, fpga_sysfs_06) {
 	char full_path[SYSFS_PATH_MAX] = { 0 };
 
 	if (snprintf(full_path, SYSFS_PATH_MAX,
-		"%s%s", tok->sysfspath, "/dfl*/*spi*/spi_master/spi*/**/security/*flash_count") < 0) {
+		"%s%s", tok->sysfspath, "/dfl*/*spi_master/spi*/**/security/*flash_count") < 0) {
 		OPAE_ERR("snprintf buffer overflow");
 	}
 
@@ -833,7 +833,7 @@ TEST_P(sysfs_c_mock_p, fpga_sysfs_07) {
 	fpga_result result;
 
 	if (snprintf(full_path, SYSFS_PATH_MAX,
-		"%s%s", tok->sysfspath, "/dfl*/*spi*/spi_master/spi*/**/security/*test_count") < 0) {
+		"%s%s", tok->sysfspath, "/dfl*/*spi_master/spi*/**/security/*test_count") < 0) {
 		OPAE_ERR("snprintf buffer overflow");
 	}
 
@@ -861,7 +861,7 @@ TEST_P(sysfs_c_mock_p, fpga_sysfs_08) {
 	fpga_result result;
 
 	if (snprintf(full_path, SYSFS_PATH_MAX,
-		"%s%s", tok->sysfspath, "/dfl*/*spi*/spi_master/spi*/**/security/**/*flash_count") < 0) {
+		"%s%s", tok->sysfspath, "/dfl*/*spi_master/spi*/**/security/**/*flash_count") < 0) {
 		OPAE_ERR("snprintf buffer overflow");
 	}
 

--- a/tests/xfpga/test_sysfs_c.cpp
+++ b/tests/xfpga/test_sysfs_c.cpp
@@ -873,6 +873,57 @@ TEST_P(sysfs_c_mock_p, fpga_sysfs_08) {
 		EXPECT_EQ(xfpga_fpgaDestroyObject(&object), FPGA_OK);
 	}
 }
+/*
+* @test      sysfs
+* @brief     Tests: find_glob_path
+ @details    When passed with valid sysfs path with "**" to
+*            find_glob_path functin recursively walks
+*            in SYSFS directory hierarchy and finds sysfs path <br>
+*            Then the return value FPGA_OK <br>
+*            When passed with invalid sysfs path with multipule "**" to
+*            find_glob_path functin recursively walks
+*            in SYSFS directory hierarchy and returns error <br>
+*            Then the return value FPGA_NOT_FOUND <br>
+*/
+TEST_P(sysfs_c_mock_p, fpga_sysfs_30) {
+	char glob_path[SYSFS_PATH_MAX] = { 0 };
+	char path[SYSFS_PATH_MAX] = { 0 };
+	_fpga_token *tok = static_cast<_fpga_token *>(tokens_[0]);
+
+	if (snprintf(glob_path, SYSFS_PATH_MAX,
+		"%s%s", tok->sysfspath,
+		"/dfl*/*spi*/*spi*/*spi*/**/security/*flash_count") < 0) {
+		OPAE_ERR("snprintf buffer overflow");
+	}
+	EXPECT_EQ(find_glob_path(glob_path, path), FPGA_OK);
+
+	memset(&glob_path, 0, sizeof(SYSFS_PATH_MAX));
+	if (snprintf(glob_path, SYSFS_PATH_MAX,
+		"%s%s", tok->sysfspath,
+		"/dfl*/*spi*/*spi*/*spi*/*spi*/**/security/*flash_count") < 0) {
+		OPAE_ERR("snprintf buffer overflow");
+	}
+	EXPECT_EQ(find_glob_path(glob_path, path), FPGA_OK);
+
+	memset(&glob_path, 0, sizeof(SYSFS_PATH_MAX));
+	if (snprintf(glob_path, SYSFS_PATH_MAX,
+		"%s%s", tok->sysfspath,
+		"/dfl*/*spi*/*spi*/*spi*/*spi*/*/security/*flash_count") < 0) {
+		OPAE_ERR("snprintf buffer overflow");
+	}
+	EXPECT_EQ(find_glob_path(glob_path, path), FPGA_NOT_FOUND);
+
+	memset(&glob_path, 0, sizeof(SYSFS_PATH_MAX));
+	if (snprintf(glob_path, SYSFS_PATH_MAX,
+		"%s%s", tok->sysfspath,
+		"/dfl*/*spi*/*spi*/*spi*/*spi*/**/security/*test_count") < 0) {
+		OPAE_ERR("snprintf buffer overflow");
+	}
+	EXPECT_EQ(find_glob_path(glob_path, path), FPGA_NOT_FOUND);
+
+	EXPECT_EQ(find_glob_path(NULL, path), FPGA_INVALID_PARAM);
+	EXPECT_EQ(find_glob_path(glob_path, NULL), FPGA_INVALID_PARAM);
+}
 INSTANTIATE_TEST_CASE_P(sysfs_c, sysfs_c_mock_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));
 

--- a/tests/xfpga/test_sysfs_c.cpp
+++ b/tests/xfpga/test_sysfs_c.cpp
@@ -807,7 +807,7 @@ TEST_P(sysfs_c_mock_p, fpga_sysfs_06) {
 	char full_path[SYSFS_PATH_MAX] = { 0 };
 
 	if (snprintf(full_path, SYSFS_PATH_MAX,
-		"%s%s", tok->sysfspath, "/dfl*/*spi_master/spi*/**/security/*flash_count") < 0) {
+		"%s%s", tok->sysfspath, "/dfl*/*spi*/spi_master/spi*/**/security/*flash_count") < 0) {
 		OPAE_ERR("snprintf buffer overflow");
 	}
 
@@ -833,7 +833,7 @@ TEST_P(sysfs_c_mock_p, fpga_sysfs_07) {
 	fpga_result result;
 
 	if (snprintf(full_path, SYSFS_PATH_MAX,
-		"%s%s", tok->sysfspath, "/dfl*/*spi_master/spi*/**/security/*test_count") < 0) {
+		"%s%s", tok->sysfspath, "/dfl*/*spi*/spi_master/spi*/**/security/*test_count") < 0) {
 		OPAE_ERR("snprintf buffer overflow");
 	}
 
@@ -861,7 +861,7 @@ TEST_P(sysfs_c_mock_p, fpga_sysfs_08) {
 	fpga_result result;
 
 	if (snprintf(full_path, SYSFS_PATH_MAX,
-		"%s%s", tok->sysfspath, "/dfl*/*spi_master/spi*/**/security/**/*flash_count") < 0) {
+		"%s%s", tok->sysfspath, "/dfl*/*spi*/spi_master/spi*/**/security/**/*flash_count") < 0) {
 		OPAE_ERR("snprintf buffer overflow");
 	}
 


### PR DESCRIPTION
Add support for the officially reservered PCI device id
for OFS devices.

Signed-off-by: Matthew Gerlach <matthew.gerlach@linux.intel.com>