### PR TITLE
cxx bindings: add token and parent accessors

### DIFF
--- a/include/opae/cxx/core/handle.h
+++ b/include/opae/cxx/core/handle.h
@@ -1,4 +1,4 @@
-// Copyright(c) 2018, Intel Corporation
+// Copyright(c) 2018-2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -180,6 +180,11 @@ class handle {
    * The destructor for handle will call close.
    */
   fpga_result close();
+
+  /** Retrieve the token corresponding to this handle
+   * object.
+   */
+  token::ptr_t get_token() const;
 
  private:
   handle(fpga_handle h);

--- a/include/opae/cxx/core/token.h
+++ b/include/opae/cxx/core/token.h
@@ -1,4 +1,4 @@
-// Copyright(c) 2018, Intel Corporation
+// Copyright(c) 2018-2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -63,10 +63,17 @@ class token {
    */
   operator fpga_token() const { return token_; }
 
+  /** Retrieve the parent token, or an empty pointer
+   * if there is none.
+   */
+  ptr_t get_parent() const;
+
  private:
   token(fpga_token tok);
 
   fpga_token token_;
+
+  friend class handle;
 };
 
 }  // end of namespace types

--- a/libopaecxx/src/handle.cpp
+++ b/libopaecxx/src/handle.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018, Intel Corporation
+// Copyright(c) 2018-2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -122,6 +122,11 @@ uint8_t *handle::mmio_ptr(uint64_t offset, uint32_t csr_space) const {
 
   ASSERT_FPGA_OK(res);
   return base + offset;
+}
+
+token::ptr_t handle::get_token() const {
+  token::ptr_t p(new token(token_));
+  return p;
 }
 
 }  // end of namespace types

--- a/libopaecxx/src/token.cpp
+++ b/libopaecxx/src/token.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018, Intel Corporation
+// Copyright(c) 2018-2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -84,6 +84,14 @@ token::~token() {
 token::token(fpga_token tok) {
   auto res = fpgaCloneToken(tok, &token_);
   ASSERT_FPGA_OK(res);
+}
+
+token::ptr_t token::get_parent() const {
+  ptr_t p;
+  auto props = properties::get(token_);
+  if (props->parent)
+    p.reset(new token(props->parent));
+  return p;
 }
 
 }  // end of namespace types

--- a/tests/opae-cxx/test_handle_cxx_core.cpp
+++ b/tests/opae-cxx/test_handle_cxx_core.cpp
@@ -214,5 +214,22 @@ TEST_P(handle_cxx_core, mmio_ptr) {
   ASSERT_NE(nullptr, h);
 }
 
+/**
+ * @test get_token
+ * Verify that handle::get_token can retrieve the token
+ * object and that token::get_parent can retrieve the
+ * parent token object.
+ */
+TEST_P(handle_cxx_core, get_token) {
+  handle_ = handle::open(tokens_[0], 0);
+  ASSERT_NE(nullptr, handle_.get());
+
+  auto tok = handle_->get_token();
+  ASSERT_NE(nullptr, tok.get());
+
+  auto par = tok->get_parent();
+  ASSERT_NE(nullptr, par.get());
+}
+
 INSTANTIATE_TEST_CASE_P(handle, handle_cxx_core,
                         ::testing::ValuesIn(test_platform::keys(true)));


### PR DESCRIPTION
Add get_parent() accessor to the token class. Enables
querying a token::ptr_t based on token::token_'s parent.

Add get_token() accessor to the handle class. Enables
querying a token::ptr_t base on handle::token_.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>