### PR TITLE
opae-v: implement the events API

### DIFF
--- a/include/opae/vfio.h
+++ b/include/opae/vfio.h
@@ -379,7 +379,8 @@ int opae_vfio_irq_mask(struct opae_vfio *v,
 		       uint32_t index);
 
 int opae_vfio_irq_disable(struct opae_vfio *v,
-			  uint32_t index);
+			  uint32_t index,
+			  uint32_t subindex);
 
 /**
  * Release and close a VFIO device

--- a/plugins/vfio/opae_vfio.c
+++ b/plugins/vfio/opae_vfio.c
@@ -40,6 +40,8 @@
 #include <time.h>
 #include <uuid/uuid.h>
 #include <sys/stat.h>
+#include <sys/eventfd.h>
+#include <unistd.h>
 
 #undef _GNU_SOURCE
 #include <opae/fpga.h>
@@ -51,6 +53,7 @@
 #define BAR_MAX 6
 #define VFIO_TOKEN_MAGIC 0xEF1010FE
 #define VFIO_HANDLE_MAGIC ~VFIO_TOKEN_MAGIC
+#define VFIO_EVENT_HANDLE_MAGIC 0x5a6446a5
 
 #define FPGA_BBS_VER_MAJOR(i) (((i) >> 56) & 0xf)
 #define FPGA_BBS_VER_MINOR(i) (((i) >> 52) & 0xf)
@@ -344,6 +347,18 @@ vfio_handle *handle_check(fpga_handle handle)
 	return h;
 }
 
+vfio_event_handle *event_handle_check(fpga_event_handle event_handle)
+{
+	ASSERT_NOT_NULL_RESULT(event_handle, NULL);
+	vfio_event_handle *eh = (vfio_event_handle *)event_handle;
+
+	if (eh->magic != VFIO_EVENT_HANDLE_MAGIC) {
+		OPAE_ERR("invalid event handle magic");
+		return NULL;
+	}
+	return eh;
+}
+
 vfio_handle *handle_check_and_lock(fpga_handle handle)
 {
 	vfio_handle *h = handle_check(handle);
@@ -353,6 +368,18 @@ vfio_handle *handle_check_and_lock(fpga_handle handle)
 		return NULL;
 	}
 	return h;
+}
+
+vfio_event_handle *
+event_handle_check_and_lock(fpga_event_handle event_handle)
+{
+	vfio_event_handle *eh = event_handle_check(event_handle);
+
+	if (eh && pthread_mutex_lock(&eh->lock)) {
+		OPAE_ERR("failed to lock event handle mutex");
+		return NULL;
+	}
+	return eh;
 }
 
 static int close_vfio_pair(vfio_pair_t **pair)
@@ -570,6 +597,13 @@ fpga_result vfio_fpgaOpen(fpga_token token, fpga_handle *handle, int flags)
 	_handle->mmio_base = (volatile uint8_t *)(mmio);
 	_handle->mmio_size = size;
 
+	if (opae_vfio_irq_unmask(_handle->vfio_pair->device,
+				 VFIO_PCI_MSIX_IRQ_INDEX)) {
+		OPAE_ERR("error unmasking MSIX IRQs");
+		res = FPGA_EXCEPTION;
+		goto out_attr_destroy;
+	}
+
 	_handle->flags = 0;
 #if GCC_VERSION >= 40900
 	__builtin_cpu_init();
@@ -602,6 +636,12 @@ fpga_result vfio_fpgaClose(fpga_handle handle)
 		free(h->token);
 	else
 		OPAE_MSG("invalid token in handle");
+
+	if (opae_vfio_irq_mask(h->vfio_pair->device,
+			       VFIO_PCI_MSIX_IRQ_INDEX)) {
+		OPAE_ERR("masking MSIX IRQs");
+		res = FPGA_EXCEPTION;
+	}
 
 	close_vfio_pair(&h->vfio_pair);
 	if (pthread_mutex_unlock(&h->lock) ||
@@ -1295,22 +1335,145 @@ out_unlock:
 
 fpga_result vfio_fpgaCreateEventHandle(fpga_event_handle *event_handle)
 {
-	(void)event_handle;
+	vfio_event_handle *_veh;
+	fpga_result res = FPGA_OK;
+	pthread_mutexattr_t mattr;
+	int err;
+
+	ASSERT_NOT_NULL(event_handle);
+
+	_veh = malloc(sizeof(vfio_event_handle));
+	if (!_veh) {
+		OPAE_ERR("Out of memory");
+		return FPGA_NO_MEMORY;
+	}
+
+	_veh->magic = VFIO_EVENT_HANDLE_MAGIC;
+
+	_veh->fd = eventfd(0, 0);
+	if (_veh->fd < 0) {
+		OPAE_ERR("eventfd : %s", strerror(errno));
+		res = FPGA_EXCEPTION;
+		goto out_free;
+	}
+
+	if (pthread_mutexattr_init(&mattr)) {
+		OPAE_ERR("Failed to init event handle mutex attr");
+		res = FPGA_EXCEPTION;
+		goto out_free;
+	}
+
+	if (pthread_mutexattr_settype(&mattr, PTHREAD_MUTEX_RECURSIVE) ||
+	    pthread_mutex_init(&_veh->lock, &mattr)) {
+		OPAE_ERR("Failed to initialize event handle lock");
+		res = FPGA_EXCEPTION;
+		goto out_attr_destroy;
+	}
+
+	pthread_mutexattr_destroy(&mattr);
+
+	*event_handle = (fpga_event_handle)_veh;
 	return FPGA_OK;
+
+out_attr_destroy:
+	err = pthread_mutexattr_destroy(&mattr);
+	if (err) {
+		OPAE_ERR("pthread_mutexattr_destroy() failed: %s",
+			 strerror(err));
+	}
+out_free:
+	free(_veh);
+	return res;
 }
 
 fpga_result vfio_fpgaDestroyEventHandle(fpga_event_handle *event_handle)
 {
-	(void)event_handle;
+	vfio_event_handle *_veh;
+	int err;
+
+	ASSERT_NOT_NULL(event_handle);
+
+	_veh = event_handle_check_and_lock(*event_handle);
+	ASSERT_NOT_NULL(_veh);
+
+	if (close(_veh->fd) < 0) {
+		OPAE_ERR("eventfd : %s", strerror(errno));
+		err = pthread_mutex_unlock(&_veh->lock);
+		if (err)
+			OPAE_ERR("pthread_mutex_unlock() failed: %s",
+				 strerror(err));
+		return (errno == EBADF) ? FPGA_INVALID_PARAM : FPGA_EXCEPTION;
+	}
+
+	_veh->magic = ~_veh->magic;
+
+	err = pthread_mutex_unlock(&_veh->lock);
+	if (err)
+		OPAE_ERR("pthread_mutex_unlock() failed: %s",
+			 strerror(errno));
+
+	err = pthread_mutex_destroy(&_veh->lock);
+	if (err)
+		OPAE_ERR("pthread_mutex_destroy() failed: %s",
+			 strerror(errno));
+
+	free(*event_handle);
+	*event_handle = NULL;
 	return FPGA_OK;
 }
 
 fpga_result vfio_fpgaGetOSObjectFromEventHandle(const fpga_event_handle eh,
 						int *fd)
 {
-	(void)eh;
-	(void)fd;
+	vfio_event_handle *_veh;
+	int err;
+
+	ASSERT_NOT_NULL(eh);
+	ASSERT_NOT_NULL(fd);
+
+	_veh = event_handle_check_and_lock(eh);
+	ASSERT_NOT_NULL(_veh);
+
+	*fd = _veh->fd;
+
+	err = pthread_mutex_unlock(&_veh->lock);
+	if (err)
+		OPAE_ERR("pthread_mutex_unlock() failed: %s",
+			 strerror(errno));
+
 	return FPGA_OK;
+}
+
+STATIC fpga_result register_event(vfio_handle *_h,
+				  fpga_event_type event_type,
+				  vfio_event_handle *_veh,
+				  uint32_t flags)
+{
+	switch (event_type) {
+	case FPGA_EVENT_ERROR:
+
+		if (opae_vfio_irq_enable(_h->vfio_pair->device,
+					 VFIO_PCI_MSIX_IRQ_INDEX,
+					 flags,
+					 _veh->fd)) {
+			OPAE_ERR("Couldn't enable MSIX IRQ %u : %s",
+				 flags, strerror(errno));
+			return FPGA_EXCEPTION;
+		}
+
+		_veh->flags = flags;
+
+		return FPGA_OK;
+	case FPGA_EVENT_INTERRUPT:
+		OPAE_ERR("User interrupts are not currently supported.");
+		return FPGA_NOT_SUPPORTED;
+	case FPGA_EVENT_POWER_THERMAL:
+		OPAE_ERR("Thermal interrupts are not currently supported.");
+		return FPGA_NOT_SUPPORTED;
+	default:
+		OPAE_ERR("Invalid event type");
+		return FPGA_EXCEPTION;
+	}
 }
 
 fpga_result vfio_fpgaRegisterEvent(fpga_handle handle,
@@ -1318,19 +1481,91 @@ fpga_result vfio_fpgaRegisterEvent(fpga_handle handle,
 				   fpga_event_handle event_handle,
 				   uint32_t flags)
 {
-	(void)handle;
-	(void)event_type;
-	(void)event_handle;
-	(void)flags;
-	return FPGA_OK;
+	vfio_handle *_h;
+	vfio_event_handle *_veh;
+	fpga_result res = FPGA_OK;
+	int err;
+
+	ASSERT_NOT_NULL(handle);
+	ASSERT_NOT_NULL(event_handle);
+
+	_h = handle_check_and_lock(handle);
+	ASSERT_NOT_NULL(_h);
+
+	_veh = event_handle_check_and_lock(handle);
+	if (!_veh)
+		goto out_unlock_handle;
+
+	res = register_event(_h, event_type, _veh, flags);
+
+	err = pthread_mutex_unlock(&_veh->lock);
+	if (err)
+		OPAE_ERR("pthread_mutex_unlock() failed: %s",
+			 strerror(errno));
+out_unlock_handle:
+	err = pthread_mutex_unlock(&_h->lock);
+	if (err)
+		OPAE_ERR("pthread_mutex_unlock() failed: %s",
+			 strerror(errno));
+	return res;
+}
+
+STATIC fpga_result unregister_event(vfio_handle *_h,
+				    fpga_event_type event_type,
+				    vfio_event_handle *_veh)
+{
+	switch (event_type) {
+	case FPGA_EVENT_ERROR:
+
+		if (opae_vfio_irq_disable(_h->vfio_pair->device,
+					  VFIO_PCI_MSIX_IRQ_INDEX)) {
+			OPAE_ERR("Couldn't disable MSIX IRQ %u : %s",
+				 _veh->flags, strerror(errno));
+			return FPGA_EXCEPTION;
+		}
+
+		return FPGA_OK;
+	case FPGA_EVENT_INTERRUPT:
+		OPAE_ERR("User interrupts are not currently supported.");
+		return FPGA_NOT_SUPPORTED;
+	case FPGA_EVENT_POWER_THERMAL:
+		OPAE_ERR("Thermal interrupts are not currently supported.");
+		return FPGA_NOT_SUPPORTED;
+	default:
+		OPAE_ERR("Invalid event type");
+		return FPGA_EXCEPTION;
+	}
 }
 
 fpga_result vfio_fpgaUnregisterEvent(fpga_handle handle,
 				     fpga_event_type event_type,
 				     fpga_event_handle event_handle)
 {
-	(void)handle;
-	(void)event_type;
-	(void)event_handle;
-	return FPGA_OK;
+	vfio_handle *_h;
+	vfio_event_handle *_veh;
+	fpga_result res = FPGA_OK;
+	int err;
+
+	ASSERT_NOT_NULL(handle);
+	ASSERT_NOT_NULL(event_handle);
+
+	_h = handle_check_and_lock(handle);
+	ASSERT_NOT_NULL(_h);
+
+	_veh = event_handle_check_and_lock(handle);
+	if (!_veh)
+		goto out_unlock_handle;
+
+	res = unregister_event(_h, event_type, _veh);
+
+	err = pthread_mutex_unlock(&_veh->lock);
+	if (err)
+		OPAE_ERR("pthread_mutex_unlock() failed: %s",
+			 strerror(errno));
+out_unlock_handle:
+	err = pthread_mutex_unlock(&_h->lock);
+	if (err)
+		OPAE_ERR("pthread_mutex_unlock() failed: %s",
+			 strerror(errno));
+	return res;
 }

--- a/plugins/vfio/opae_vfio.c
+++ b/plugins/vfio/opae_vfio.c
@@ -1518,7 +1518,8 @@ STATIC fpga_result unregister_event(vfio_handle *_h,
 	case FPGA_EVENT_ERROR:
 
 		if (opae_vfio_irq_disable(_h->vfio_pair->device,
-					  VFIO_PCI_MSIX_IRQ_INDEX)) {
+					  VFIO_PCI_MSIX_IRQ_INDEX,
+					  _veh->flags)) {
 			OPAE_ERR("Couldn't disable MSIX IRQ %u : %s",
 				 _veh->flags, strerror(errno));
 			return FPGA_EXCEPTION;

--- a/plugins/vfio/opae_vfio.h
+++ b/plugins/vfio/opae_vfio.h
@@ -131,6 +131,12 @@ typedef struct _vfio_handle {
 	uint32_t flags;
 } vfio_handle;
 
+typedef struct _vfio_event_handle {
+	uint32_t magic;
+	pthread_mutex_t lock;
+	int fd;
+	uint32_t flags;
+} vfio_event_handle;
 
 int pci_discover(void);
 int features_discover(void);


### PR DESCRIPTION
The implementation is currently limited to support for
FPGA_EVENT_ERROR.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>