### PR TITLE
opae-libs: fix metrics sysfs path for n6010

### DIFF
--- a/plugins/xfpga/metrics/metrics_max10.c
+++ b/plugins/xfpga/metrics/metrics_max10.c
@@ -169,7 +169,8 @@ fpga_result  dfl_enum_max10_metrics_info(struct _fpga_handle *_handle,
 
 	if (_handle == NULL ||
 		vector == NULL ||
-		metric_num == NULL) {
+		metric_num == NULL ||
+		hw_type == FPGA_HW_UNKNOWN) {
 		OPAE_ERR("Invalid Input parameters");
 		return FPGA_INVALID_PARAM;
 	}

--- a/plugins/xfpga/metrics/metrics_max10.h
+++ b/plugins/xfpga/metrics/metrics_max10.h
@@ -33,8 +33,8 @@
 #define __FPGA_METRICS_MAX10_H__
 
 
-#define DFL_MAX10_SYSFS_PATH                     "*dfl*/*spi*/*spi*/**/hwmon/hwmon*/"
-#define DFL_MAX10_SYSFS_LABEL                    "*_label"
+#define DFL_MAX10_SYSFS_PATH                    "*dfl_*/**/hwmon/hwmon*/"
+#define DFL_MAX10_SYSFS_LABEL                   "*_label"
 #define DFL_TEMPERATURE                         "temp"
 #define DFL_VOLTAGE                             "in"
 #define DFL_CURRENT                             "curr"

--- a/plugins/xfpga/metrics/metrics_max10.h
+++ b/plugins/xfpga/metrics/metrics_max10.h
@@ -33,7 +33,7 @@
 #define __FPGA_METRICS_MAX10_H__
 
 
-#define DFL_MAX10_SYSFS_PATH                    "*dfl_*/*/**/hwmon/hwmon*/"
+#define DFL_MAX10_SYSFS_PATH                    "*dfl_*/*/**/*hwmon*/hwmon/hwmon*/"
 #define DFL_MAX10_SYSFS_LABEL                   "*_label"
 #define DFL_TEMPERATURE                         "temp"
 #define DFL_VOLTAGE                             "in"

--- a/plugins/xfpga/metrics/metrics_max10.h
+++ b/plugins/xfpga/metrics/metrics_max10.h
@@ -33,7 +33,7 @@
 #define __FPGA_METRICS_MAX10_H__
 
 
-#define DFL_MAX10_SYSFS_PATH                    "*dfl_*/**/hwmon/hwmon*/"
+#define DFL_MAX10_SYSFS_PATH                    "*dfl_*/*/**/hwmon/hwmon*/"
 #define DFL_MAX10_SYSFS_LABEL                   "*_label"
 #define DFL_TEMPERATURE                         "temp"
 #define DFL_VOLTAGE                             "in"

--- a/plugins/xfpga/metrics/metrics_utils.c
+++ b/plugins/xfpga/metrics/metrics_utils.c
@@ -584,18 +584,14 @@ fpga_result enum_fpga_metrics(fpga_handle handle)
 		case FPGA_HW_DCP_N5010:
 		case FPGA_HW_DCP_N5011: {
 
-			memset(metrics_path, 0, SYSFS_PATH_MAX);
-			if (sysfs_get_max10_path(_token, metrics_path) == FPGA_OK) {
-					// Max10 Power & Thermal
-					result = dfl_enum_max10_metrics_info(_handle,
-						&(_handle->fpga_enum_metric_vector),
-						&metric_num,
-						hw_type);
-						if (result != FPGA_OK) {
-							OPAE_ERR("Failed to Enum Power and Thermal metrics.");
-						}
-			}
-
+			// Max10 Power & Thermal
+			result = dfl_enum_max10_metrics_info(_handle,
+					&(_handle->fpga_enum_metric_vector),
+					&metric_num,
+					hw_type);
+					if (result != FPGA_OK) {
+						OPAE_ERR("Failed to Enum Power and Thermal metrics.");
+					}
 		}
 		break;
 

--- a/tests/xfpga/test_metrics_max10_c.cpp
+++ b/tests/xfpga/test_metrics_max10_c.cpp
@@ -113,7 +113,7 @@ TEST_P(metrics_max10_c_p, test_metric_max10_1) {
   void *buf = NULL;
   char file[] = "curr1_input";
   char sysfs[] =
-		"/sys/class/fpga_region/region*/dfl-fme.*/dfl-fme.*/*spi*/"
+		"/sys/class/fpga_region/region*/dfl-fme.*/dfl*/*spi*/"
 		"spi_master/spi*/spi*/*-hwmon.*.auto/hwmon/hwmon*";
 
   EXPECT_NE(read_sensor_sysfs_file(NULL, file, &buf, &tot_bytes_ret), FPGA_OK);
@@ -180,13 +180,13 @@ TEST_P(metrics_max10_c_p, test_metric_max10_2) {
   EXPECT_NE(FPGA_OK,
 	  dfl_enum_max10_metrics_info(_handle, &vector, NULL, FPGA_HW_DCP_N3000));
 
-  EXPECT_EQ(FPGA_OK, dfl_enum_max10_metrics_info(_handle, &vector, &metric_num,
+  EXPECT_EQ(FPGA_INVALID_PARAM, dfl_enum_max10_metrics_info(_handle, &vector, &metric_num,
                                              FPGA_HW_UNKNOWN));
 
   EXPECT_EQ(FPGA_OK, fpga_vector_free(&vector));
 }
 INSTANTIATE_TEST_CASE_P(metrics_max10_c, metrics_max10_c_p,
-    ::testing::ValuesIn(test_platform::mock_platforms({"dfl-d5005"})));
+    ::testing::ValuesIn(test_platform::mock_platforms({"dfl-n3000"})));
 
 class metrics_invalid_max10_c_p : public metrics_max10_c_p {};
 


### PR DESCRIPTION
  N6010 sensor sysfs  path: /sys/class/fpga_region/region0/dfl-fme.0/dfl_dev.2/n6010bmc-hwmon.2.auto/hwmon/
  IOFS R1 sensor path :  "/sys/bus/pci/devices/%s/fpga_region/region*/dfl-fme.*/"
                 "dfl_dev.*/subdev_spi_altera.*.auto/spi_master/spi*/spi*.*/"
                 "*-hwmon.*.auto/hwmon/hwmon*/*_label"

   Max10 metrics recursive function with input  "*dfl_*/**/hwmon/hwmon*/" enumerates both N6010 and IOFSR1 sensor paths

Signed-off-by: anandaravuri <ananda.ravuri@intel.com>