### PR TITLE
libopaevfio: add safeguards for invalid vectors

### DIFF
--- a/libopaevfio/opaevfio.c
+++ b/libopaevfio/opaevfio.c
@@ -825,7 +825,7 @@ int opae_vfio_irq_enable(struct opae_vfio *v,
 			struct vfio_irq_set *i;
 			char buf[sizeof(*i) + sizeof(int32_t)];
 			int32_t *fdptr;
-			int res;
+			int res = 3;
 
 			i = (struct vfio_irq_set *)buf;
 			i->argsz = sizeof(buf);
@@ -838,13 +838,18 @@ int opae_vfio_irq_enable(struct opae_vfio *v,
 			fdptr = (int32_t *)&i->data;
 			*fdptr = event_fd;
 
-			res = ioctl(v->device.device_fd,
-				    VFIO_DEVICE_SET_IRQS,
-				    i);
+			if (subindex < irq->count) {
+				res = ioctl(v->device.device_fd,
+					    VFIO_DEVICE_SET_IRQS,
+					    i);
 
-			if (res < 0)
-				ERR("ioctl(fd, VFIO_DEVICE_SET_IRQS, i)"
-				    " [enable]\n");
+				if (res < 0)
+					ERR("ioctl(fd, VFIO_DEVICE_SET_IRQS, i)"
+					    " [enable]\n");
+			} else {
+				ERR("subindex %u is out of range 0-%u\n",
+				    subindex, irq->count - 1);
+			}
 
 			return res;
 		}
@@ -868,7 +873,7 @@ int opae_vfio_irq_unmask(struct opae_vfio *v,
 		if ((irq->index == index) &&
 		    (irq->flags & VFIO_IRQ_INFO_MASKABLE)) {
 			struct vfio_irq_set i;
-			int res;
+			int res = 3;
 
 			i.argsz = sizeof(i);
 			i.flags = VFIO_IRQ_SET_ACTION_UNMASK |
@@ -877,13 +882,18 @@ int opae_vfio_irq_unmask(struct opae_vfio *v,
 			i.start = subindex;
 			i.count = 1;
 
-			res = ioctl(v->device.device_fd,
-				    VFIO_DEVICE_SET_IRQS,
-				    &i);
+			if (subindex < irq->count) {
+				res = ioctl(v->device.device_fd,
+					    VFIO_DEVICE_SET_IRQS,
+					    &i);
 
-			if (res < 0)
-				ERR("ioctl(fd, VFIO_DEVICE_SET_IRQS, i)"
-				    " [unmask]\n");
+				if (res < 0)
+					ERR("ioctl(fd, VFIO_DEVICE_SET_IRQS, i)"
+					    " [unmask]\n");
+			} else {
+				ERR("subindex %u is out of range 0-%u\n",
+				    subindex, irq->count - 1);
+			}
 
 			return res;
 		}
@@ -907,7 +917,7 @@ int opae_vfio_irq_mask(struct opae_vfio *v,
 		if ((irq->index == index) &&
 		    (irq->flags & VFIO_IRQ_INFO_MASKABLE)) {
 			struct vfio_irq_set i;
-			int res;
+			int res = 3;
 
 			i.argsz = sizeof(i);
 			i.flags = VFIO_IRQ_SET_ACTION_MASK |
@@ -916,13 +926,18 @@ int opae_vfio_irq_mask(struct opae_vfio *v,
 			i.start = subindex;
 			i.count = 1;
 
-			res = ioctl(v->device.device_fd,
-				    VFIO_DEVICE_SET_IRQS,
-				    &i);
+			if (subindex < irq->count) {
+				res = ioctl(v->device.device_fd,
+					    VFIO_DEVICE_SET_IRQS,
+					    &i);
 
-			if (res < 0)
-				ERR("ioctl(fd, VFIO_DEVICE_SET_IRQS, i)"
-				    " [mask]\n");
+				if (res < 0)
+					ERR("ioctl(fd, VFIO_DEVICE_SET_IRQS, i)"
+					    " [mask]\n");
+			} else {
+				ERR("subindex %u is out of range 0-%u\n",
+				    subindex, irq->count - 1);
+			}
 
 			return res;
 		}
@@ -948,7 +963,7 @@ int opae_vfio_irq_disable(struct opae_vfio *v,
 			struct vfio_irq_set *i;
 			char buf[sizeof(*i) + sizeof(int32_t)];
 			int32_t *fdptr;
-			int res;
+			int res = 3;
 
 			i = (struct vfio_irq_set *)buf;
 			i->argsz = sizeof(buf);
@@ -961,13 +976,18 @@ int opae_vfio_irq_disable(struct opae_vfio *v,
 			fdptr = (int32_t *)&i->data;
 			*fdptr = -1;
 
-			res = ioctl(v->device.device_fd,
-				    VFIO_DEVICE_SET_IRQS,
-				    i);
+			if (subindex < irq->count) {
+				res = ioctl(v->device.device_fd,
+					    VFIO_DEVICE_SET_IRQS,
+					    i);
 
-			if (res < 0)
-				ERR("ioctl(fd, VFIO_DEVICE_SET_IRQS, i)"
-				    " [disable]\n");
+				if (res < 0)
+					ERR("ioctl(fd, VFIO_DEVICE_SET_IRQS, i)"
+					    " [disable]\n");
+			} else {
+				ERR("subindex %u is out of range 0-%u\n",
+				    subindex, irq->count - 1);
+			}
 
 			return res;
 		}


### PR DESCRIPTION
Adds a check for invalid IRQ vector argument (subindex) to the
IRQ APIs. The given vector must be less than the irq->count.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>